### PR TITLE
Add function for replacing parameters with arguments.

### DIFF
--- a/src/main/scala/com/github/kmizu/hopeg/HOPEGRunner.scala
+++ b/src/main/scala/com/github/kmizu/hopeg/HOPEGRunner.scala
@@ -7,10 +7,10 @@ object HOPEGRunner {
   def main(args: Array[String]): Unit = {
     val grammar = HOPEGParser.parse(
       """
-        |S = REP("a") !.; REP(s) = s*;
+        |S = REP("a") !.; REP(s) = s REP(s) | "";
       """.stripMargin)
     val evaluator = new HOPEGEvaluator(grammar)
     val input = "aaaaa"
-    println(evaluator.evaluate("aaaaa", 'S).map{in => s"matched to ${input}"}.getOrElse{s"not matched to ${input}"})
+    println(evaluator.evaluate(input, 'S).map{in => s"matched to ${input}"}.getOrElse{s"not matched to ${input}"})
   }
 }


### PR DESCRIPTION
"bindings" in "evaluate" refer parameter itself after evaluating Ast.Call twice.
This makes infinite recursion with evaluate.
To avoid this, I add "extraction" function to replace parameters in Ast.Call by arguments.
