### PR TITLE
fix some warnings in Scala 2.13.0-M4

### DIFF
--- a/src/main/scala/com/github/kmizu/macro_peg/MacroPEGEvaluator.scala
+++ b/src/main/scala/com/github/kmizu/macro_peg/MacroPEGEvaluator.scala
@@ -7,7 +7,7 @@ case class MacroPEGEvaluator(grammar: Ast.Grammar) {
   private def expand(node: Ast.Expression): Ast.Expression = node match {
     case Ast.CharClass(pos, positive, elems) =>
       Ast.CharSet(pos, positive, elems.foldLeft(Set[Char]()){
-        case (set, Ast.CharRange(f, t)) => (set /: (f to t))((set, c) => set + c)
+        case (set, Ast.CharRange(f, t)) => (f to t).foldLeft(set)((set, c) => set + c)
         case (set, Ast.OneChar(c)) => set + c
       })
     case Ast.Alternation(pos, e1, e2) => Ast.Alternation(pos, expand(e1), expand(e2))

--- a/src/main/scala/com/github/kmizu/macro_peg/MacroPEGParser.scala
+++ b/src/main/scala/com/github/kmizu/macro_peg/MacroPEGParser.scala
@@ -188,7 +188,7 @@ object MacroPEGParser {
     parse("", new StringReader(pattern))
   }
 
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val g = parse(args(0), new FileReader(args(0)))
     println(g)
   }


### PR DESCRIPTION
- use foldLeft instead of /: https://github.com/scala/scala/blob/v2.13.0-M4/src/library/scala/collection/IterableOnce.scala#L465
- fix procedure syntax https://github.com/scala/scala/commit/1d4d901fcea0a162cd139836b246e85cc0130a6b