### PR TITLE
Start higher-order macro support

### DIFF
--- a/src/main/scala/com/github/kmizu/macro_peg/Ast.scala
+++ b/src/main/scala/com/github/kmizu/macro_peg/Ast.scala
@@ -131,7 +131,13 @@ object Ast {
     * @param pos position in source file
     * @param name the name of this rule.  It is referred in body
     * @param body the parsing expression which this rule represents */
-  case class Rule(pos: Position, name: Symbol, body: Expression, args: List[Symbol] = Nil) extends HasPosition
+  case class Rule(
+    pos: Position,
+    name: Symbol,
+    body: Expression,
+    args: List[Symbol] = Nil,
+    argTypes: List[Option[Type]] = Nil
+  ) extends HasPosition
   /** This trait represents common super-type of parsing expression AST. */
   sealed trait Expression extends HasPosition
   /** This class represents an AST of sequence (e1 e2).

--- a/src/main/scala/com/github/kmizu/macro_peg/Parser.scala
+++ b/src/main/scala/com/github/kmizu/macro_peg/Parser.scala
@@ -36,10 +36,18 @@ object Parser {
       case pos ~ rules => Grammar(Position(pos.line, pos.column), rules)
     }
 
-    lazy val Definition: Parser[Rule] = rule(Ident  ~ ((LPAREN ~> Arg.repeat1By(COMMA) <~ RPAREN).? <~ EQ) ~ (Expression <~ SEMI_COLON).commit) ^^ {
-      case name ~ argsOpt ~ body =>
-        Rule(name.pos, name.name, body, argsOpt.getOrElse(List()).map(_._1.name))
-    }
+    lazy val Definition: Parser[Rule] =
+      rule(Ident  ~ ((LPAREN ~> Arg.repeat1By(COMMA) <~ RPAREN).? <~ EQ) ~ (Expression <~ SEMI_COLON).commit) ^^ {
+        case name ~ argsOpt ~ body =>
+          val argsWithTypes = argsOpt.getOrElse(List())
+          Rule(
+            name.pos,
+            name.name,
+            body,
+            argsWithTypes.map(_._1.name),
+            argsWithTypes.map(_._2)
+          )
+      }
 
     lazy val Arg: Parser[(Identifier, Option[Type])] = rule(Ident ~ (COLON ~> TypeTree).?) ^^ { case id ~ tpe => (id, tpe)}
 

--- a/src/test/scala/com/github/kmizu/macro_peg/HigherOrderParserSpec.scala
+++ b/src/test/scala/com/github/kmizu/macro_peg/HigherOrderParserSpec.scala
@@ -1,0 +1,21 @@
+package com.github.kmizu.macro_peg
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.diagrams.Diagrams
+
+class HigherOrderParserSpec extends AnyFunSpec with Diagrams {
+  describe("Parser with typed arguments") {
+    it("captures argument types") {
+      val grammar = Parser.parse(
+        """
+          |S = Double(Plus1, "aa") !.;
+          |Plus1(s: ?) = s s;
+          |Double(f: ?, s: ?) = f(f(s));
+        """.stripMargin)
+      val doubleRule = grammar.rules.find(_.name == Symbol("Double")).get
+      assert(doubleRule.argTypes.nonEmpty)
+      assert(doubleRule.argTypes.size == 2)
+      assert(doubleRule.argTypes.forall(_.isDefined))
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- store optional type info for rule arguments
- parse typed argument lists in `Definition`
- add test ensuring parser captures argument types

## Testing
- `sbt test`
