### PR TITLE
Implement simple macro expansion

### DIFF
--- a/src/main/scala/com/github/kmizu/macro_peg/Ast.scala
+++ b/src/main/scala/com/github/kmizu/macro_peg/Ast.scala
@@ -131,7 +131,13 @@ object Ast {
     * @param pos position in source file
     * @param name the name of this rule.  It is referred in body
     * @param body the parsing expression which this rule represents */
-  case class Rule(pos: Position, name: Symbol, body: Expression, args: List[Symbol] = Nil) extends HasPosition
+  case class Rule(
+    pos: Position,
+    name: Symbol,
+    body: Expression,
+    args: List[Symbol] = Nil,
+    argTypes: List[Option[Type]] = Nil
+  ) extends HasPosition
   /** This trait represents common super-type of parsing expression AST. */
   sealed trait Expression extends HasPosition
   /** This class represents an AST of sequence (e1 e2).

--- a/src/main/scala/com/github/kmizu/macro_peg/MacroExpander.scala
+++ b/src/main/scala/com/github/kmizu/macro_peg/MacroExpander.scala
@@ -1,0 +1,63 @@
+package com.github.kmizu.macro_peg
+
+/**
+ * Utility to expand macro calls syntactically. This is a very
+ * naive implementation intended as a first step toward
+ * higher-order macro support.
+ */
+object MacroExpander {
+  import Ast._
+
+  private def substitute(exp: Expression, env: Map[Symbol, Expression]): Expression = exp match {
+    case Identifier(pos, name) if env.contains(name) => env(name)
+    case Sequence(pos, l, r) => Sequence(pos, substitute(l, env), substitute(r, env))
+    case Alternation(pos, l, r) => Alternation(pos, substitute(l, env), substitute(r, env))
+    case Repeat0(pos, b) => Repeat0(pos, substitute(b, env))
+    case Repeat1(pos, b) => Repeat1(pos, substitute(b, env))
+    case Optional(pos, b) => Optional(pos, substitute(b, env))
+    case AndPredicate(pos, b) => AndPredicate(pos, substitute(b, env))
+    case NotPredicate(pos, b) => NotPredicate(pos, substitute(b, env))
+    case Call(pos, name, params) if env.contains(name) =>
+      env(name) match {
+        case Identifier(_, target) =>
+          Call(pos, target, params.map(p => substitute(p, env)))
+        case Function(_, fArgs, fBody) =>
+          val newParams = params.map(p => substitute(p, env))
+          val newEnv = fArgs.zip(newParams).toMap
+          substitute(fBody, newEnv)
+        case _ =>
+          Call(pos, name, params.map(p => substitute(p, env)))
+      }
+    case Call(pos, name, params) => Call(pos, name, params.map(p => substitute(p, env)))
+    case Function(pos, args, body) => Function(pos, args, substitute(body, env))
+    case Debug(pos, b) => Debug(pos, substitute(b, env))
+    case other => other
+  }
+
+  private def expand(exp: Expression, rules: Map[Symbol, Rule]): Expression = exp match {
+    case Call(pos, name, params) if rules.contains(name) =>
+      val rule = rules(name)
+      val newParams = params.map(p => expand(p, rules))
+      val env = rule.args.zip(newParams).toMap
+      val replaced = substitute(rule.body, env)
+      expand(replaced, rules)
+    case Sequence(pos, l, r) => Sequence(pos, expand(l, rules), expand(r, rules))
+    case Alternation(pos, l, r) => Alternation(pos, expand(l, rules), expand(r, rules))
+    case Repeat0(pos, b) => Repeat0(pos, expand(b, rules))
+    case Repeat1(pos, b) => Repeat1(pos, expand(b, rules))
+    case Optional(pos, b) => Optional(pos, expand(b, rules))
+    case AndPredicate(pos, b) => AndPredicate(pos, expand(b, rules))
+    case NotPredicate(pos, b) => NotPredicate(pos, expand(b, rules))
+    case Function(pos, args, body) => Function(pos, args, expand(body, rules))
+    case Debug(pos, b) => Debug(pos, expand(b, rules))
+    case other => other
+  }
+
+  def expandGrammar(grammar: Grammar): Grammar = {
+    val ruleMap = grammar.rules.map(r => r.name -> r).toMap
+    val newRules = grammar.rules.map { r =>
+      r.copy(body = expand(r.body, ruleMap))
+    }
+    grammar.copy(rules = newRules)
+  }
+}

--- a/src/main/scala/com/github/kmizu/macro_peg/Parser.scala
+++ b/src/main/scala/com/github/kmizu/macro_peg/Parser.scala
@@ -36,10 +36,18 @@ object Parser {
       case pos ~ rules => Grammar(Position(pos.line, pos.column), rules)
     }
 
-    lazy val Definition: Parser[Rule] = rule(Ident  ~ ((LPAREN ~> Arg.repeat1By(COMMA) <~ RPAREN).? <~ EQ) ~ (Expression <~ SEMI_COLON).commit) ^^ {
-      case name ~ argsOpt ~ body =>
-        Rule(name.pos, name.name, body, argsOpt.getOrElse(List()).map(_._1.name))
-    }
+    lazy val Definition: Parser[Rule] =
+      rule(Ident  ~ ((LPAREN ~> Arg.repeat1By(COMMA) <~ RPAREN).? <~ EQ) ~ (Expression <~ SEMI_COLON).commit) ^^ {
+        case name ~ argsOpt ~ body =>
+          val argsWithTypes = argsOpt.getOrElse(List())
+          Rule(
+            name.pos,
+            name.name,
+            body,
+            argsWithTypes.map(_._1.name),
+            argsWithTypes.map(_._2)
+          )
+      }
 
     lazy val Arg: Parser[(Identifier, Option[Type])] = rule(Ident ~ (COLON ~> TypeTree).?) ^^ { case id ~ tpe => (id, tpe)}
 

--- a/src/test/scala/com/github/kmizu/macro_peg/HigherOrderEvalSpec.scala
+++ b/src/test/scala/com/github/kmizu/macro_peg/HigherOrderEvalSpec.scala
@@ -1,0 +1,23 @@
+package com.github.kmizu.macro_peg
+
+import com.github.kmizu.macro_peg.EvaluationResult.{Success, Failure}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.diagrams.Diagrams
+
+class HigherOrderEvalSpec extends AnyFunSpec with Diagrams {
+  describe("Higher-order macro evaluation") {
+    it("evaluates nested macro application") {
+      val grammar = Parser.parse(
+        """S = Double(Plus1, "aa") !.;
+          |Plus1(s: ?) = s s;
+          |Double(f: ?, s: ?) = f(f(s));
+        """.stripMargin)
+      val expanded = MacroExpander.expandGrammar(grammar)
+      val evaluator = Evaluator(expanded)
+      val resultSuccess = evaluator.evaluate("aaaaaaaa", Symbol("S"))
+      val resultFailure = evaluator.evaluate("aaaa", Symbol("S"))
+      assert(resultSuccess == Success(""))
+      assert(resultFailure == Failure)
+    }
+  }
+}

--- a/src/test/scala/com/github/kmizu/macro_peg/HigherOrderParserSpec.scala
+++ b/src/test/scala/com/github/kmizu/macro_peg/HigherOrderParserSpec.scala
@@ -1,0 +1,21 @@
+package com.github.kmizu.macro_peg
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.diagrams.Diagrams
+
+class HigherOrderParserSpec extends AnyFunSpec with Diagrams {
+  describe("Parser with typed arguments") {
+    it("captures argument types") {
+      val grammar = Parser.parse(
+        """
+          |S = Double(Plus1, "aa") !.;
+          |Plus1(s: ?) = s s;
+          |Double(f: ?, s: ?) = f(f(s));
+        """.stripMargin)
+      val doubleRule = grammar.rules.find(_.name == Symbol("Double")).get
+      assert(doubleRule.argTypes.nonEmpty)
+      assert(doubleRule.argTypes.size == 2)
+      assert(doubleRule.argTypes.forall(_.isDefined))
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `MacroExpander` to perform naive macro call expansion
- test higher-order evaluation using the new expander

## Testing
- `sbt test`