### PR TITLE
Implement simple type checker with tests

### DIFF
--- a/src/main/scala/com/github/kmizu/macro_peg/Ast.scala
+++ b/src/main/scala/com/github/kmizu/macro_peg/Ast.scala
@@ -131,7 +131,13 @@ object Ast {
     * @param pos position in source file
     * @param name the name of this rule.  It is referred in body
     * @param body the parsing expression which this rule represents */
-  case class Rule(pos: Position, name: Symbol, body: Expression, args: List[Symbol] = Nil) extends HasPosition
+  case class Rule(
+    pos: Position,
+    name: Symbol,
+    body: Expression,
+    args: List[Symbol] = Nil,
+    argTypes: List[Option[Type]] = Nil
+  ) extends HasPosition
   /** This trait represents common super-type of parsing expression AST. */
   sealed trait Expression extends HasPosition
   /** This class represents an AST of sequence (e1 e2).

--- a/src/main/scala/com/github/kmizu/macro_peg/Parser.scala
+++ b/src/main/scala/com/github/kmizu/macro_peg/Parser.scala
@@ -36,10 +36,18 @@ object Parser {
       case pos ~ rules => Grammar(Position(pos.line, pos.column), rules)
     }
 
-    lazy val Definition: Parser[Rule] = rule(Ident  ~ ((LPAREN ~> Arg.repeat1By(COMMA) <~ RPAREN).? <~ EQ) ~ (Expression <~ SEMI_COLON).commit) ^^ {
-      case name ~ argsOpt ~ body =>
-        Rule(name.pos, name.name, body, argsOpt.getOrElse(List()).map(_._1.name))
-    }
+    lazy val Definition: Parser[Rule] =
+      rule(Ident  ~ ((LPAREN ~> Arg.repeat1By(COMMA) <~ RPAREN).? <~ EQ) ~ (Expression <~ SEMI_COLON).commit) ^^ {
+        case name ~ argsOpt ~ body =>
+          val argsWithTypes = argsOpt.getOrElse(List())
+          Rule(
+            name.pos,
+            name.name,
+            body,
+            argsWithTypes.map(_._1.name),
+            argsWithTypes.map(_._2)
+          )
+      }
 
     lazy val Arg: Parser[(Identifier, Option[Type])] = rule(Ident ~ (COLON ~> TypeTree).?) ^^ { case id ~ tpe => (id, tpe)}
 

--- a/src/main/scala/com/github/kmizu/macro_peg/TypeChecker.scala
+++ b/src/main/scala/com/github/kmizu/macro_peg/TypeChecker.scala
@@ -1,0 +1,68 @@
+package com.github.kmizu.macro_peg
+
+import com.github.kmizu.macro_peg.Ast._
+
+case class TypeError(pos: Position, msg: String) extends RuntimeException(s"${pos.line}:${pos.column}: $msg")
+
+object TypeChecker {
+  private val baseType: SimpleType = SimpleType(DUMMY_POSITION)
+
+  def check(grammar: Grammar): Unit = {
+    val ruleEnv: Map[Symbol, Type] = grammar.rules.map { r =>
+      val paramTypes = r.argTypes.map(_.getOrElse(baseType))
+      r.name -> RuleType(r.pos, paramTypes, baseType)
+    }.toMap
+    grammar.rules.foreach { rule =>
+      val paramEnv = rule.args.zip(rule.argTypes.map(_.getOrElse(baseType))).toMap
+      checkExpression(rule.body, ruleEnv ++ paramEnv)
+    }
+  }
+
+  private def checkSimple(pos: Position, t: Type): Unit = t match {
+    case _: SimpleType =>
+    case _: RuleType   => throw TypeError(pos, "function value used as parsing expression")
+  }
+
+  private def checkExpression(exp: Expression, env: Map[Symbol, Type]): Type = exp match {
+    case Sequence(pos, l, r) =>
+      checkSimple(pos, checkExpression(l, env))
+      checkSimple(pos, checkExpression(r, env))
+      baseType
+    case Alternation(pos, l, r) =>
+      checkSimple(pos, checkExpression(l, env))
+      checkSimple(pos, checkExpression(r, env))
+      baseType
+    case Repeat0(pos, b) =>
+      checkSimple(pos, checkExpression(b, env)); baseType
+    case Repeat1(pos, b) =>
+      checkSimple(pos, checkExpression(b, env)); baseType
+    case Optional(pos, b) =>
+      checkSimple(pos, checkExpression(b, env)); baseType
+    case AndPredicate(pos, b) =>
+      checkSimple(pos, checkExpression(b, env)); baseType
+    case NotPredicate(pos, b) =>
+      checkSimple(pos, checkExpression(b, env)); baseType
+    case Debug(pos, b) =>
+      checkExpression(b, env); baseType
+    case StringLiteral(_, _) | Wildcard(_) | CharSet(_,_,_) | CharClass(_,_,_) =>
+      baseType
+    case Identifier(_, name) =>
+      env.getOrElse(name, baseType)
+    case Call(pos, name, args) =>
+      env.get(name) match {
+        case Some(RuleType(_, paramTypes, resultType)) =>
+          if(paramTypes.length != args.length)
+            throw TypeError(pos, s"${name.name} expects ${paramTypes.length} arguments but ${args.length} were given")
+          args.foreach(a => checkExpression(a, env))
+          resultType
+        case Some(_: SimpleType) =>
+          throw TypeError(pos, s"${name.name} is not a function")
+        case None =>
+          args.foreach(a => checkExpression(a, env)); baseType
+      }
+    case Function(pos, params, body) =>
+      val localEnv = env ++ params.map(_ -> baseType)
+      val res = checkExpression(body, localEnv)
+      RuleType(pos, params.map(_ => baseType), res)
+  }
+}

--- a/src/test/scala/com/github/kmizu/macro_peg/HigherOrderParserSpec.scala
+++ b/src/test/scala/com/github/kmizu/macro_peg/HigherOrderParserSpec.scala
@@ -1,0 +1,21 @@
+package com.github.kmizu.macro_peg
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.diagrams.Diagrams
+
+class HigherOrderParserSpec extends AnyFunSpec with Diagrams {
+  describe("Parser with typed arguments") {
+    it("captures argument types") {
+      val grammar = Parser.parse(
+        """
+          |S = Double(Plus1, "aa") !.;
+          |Plus1(s: ?) = s s;
+          |Double(f: ?, s: ?) = f(f(s));
+        """.stripMargin)
+      val doubleRule = grammar.rules.find(_.name == Symbol("Double")).get
+      assert(doubleRule.argTypes.nonEmpty)
+      assert(doubleRule.argTypes.size == 2)
+      assert(doubleRule.argTypes.forall(_.isDefined))
+    }
+  }
+}

--- a/src/test/scala/com/github/kmizu/macro_peg/TypeCheckerSpec.scala
+++ b/src/test/scala/com/github/kmizu/macro_peg/TypeCheckerSpec.scala
@@ -1,0 +1,30 @@
+package com.github.kmizu.macro_peg
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.diagrams.Diagrams
+
+class TypeCheckerSpec extends AnyFunSpec with Diagrams {
+  describe("TypeChecker") {
+    it("accepts valid higher order grammar") {
+      val grammar = Parser.parse(
+        """
+          |S = Double(Plus1, "aa") !.;
+          |Plus1(s: ?) = s s;
+          |Double(f: (?)->?, s: ?) = f(f(s));
+        """.stripMargin)
+      TypeChecker.check(grammar)
+    }
+
+    it("rejects invalid function usage") {
+      val grammar = Parser.parse(
+        """
+          |S = Double(Plus1, "aa") !.;
+          |Plus1(s: ?) = s s;
+          |Double(f: (?)->?, s: ?) = f(s) f;
+        """.stripMargin)
+      assertThrows[TypeError] {
+        TypeChecker.check(grammar)
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- introduce `TypeChecker` with basic function-argument checks
- create `TypeCheckerSpec` to validate type-checking behavior

## Testing
- `sbt test`