### PR TITLE
Add type checker and higher‑order macro tests

### DIFF
--- a/src/main/scala/com/github/kmizu/macro_peg/Ast.scala
+++ b/src/main/scala/com/github/kmizu/macro_peg/Ast.scala
@@ -131,7 +131,13 @@ object Ast {
     * @param pos position in source file
     * @param name the name of this rule.  It is referred in body
     * @param body the parsing expression which this rule represents */
-  case class Rule(pos: Position, name: Symbol, body: Expression, args: List[Symbol] = Nil) extends HasPosition
+  case class Rule(
+    pos: Position,
+    name: Symbol,
+    body: Expression,
+    args: List[Symbol] = Nil,
+    argTypes: List[Option[Type]] = Nil
+  ) extends HasPosition
   /** This trait represents common super-type of parsing expression AST. */
   sealed trait Expression extends HasPosition
   /** This class represents an AST of sequence (e1 e2).

--- a/src/main/scala/com/github/kmizu/macro_peg/Parser.scala
+++ b/src/main/scala/com/github/kmizu/macro_peg/Parser.scala
@@ -36,10 +36,18 @@ object Parser {
       case pos ~ rules => Grammar(Position(pos.line, pos.column), rules)
     }
 
-    lazy val Definition: Parser[Rule] = rule(Ident  ~ ((LPAREN ~> Arg.repeat1By(COMMA) <~ RPAREN).? <~ EQ) ~ (Expression <~ SEMI_COLON).commit) ^^ {
-      case name ~ argsOpt ~ body =>
-        Rule(name.pos, name.name, body, argsOpt.getOrElse(List()).map(_._1.name))
-    }
+    lazy val Definition: Parser[Rule] =
+      rule(Ident  ~ ((LPAREN ~> Arg.repeat1By(COMMA) <~ RPAREN).? <~ EQ) ~ (Expression <~ SEMI_COLON).commit) ^^ {
+        case name ~ argsOpt ~ body =>
+          val argsWithTypes = argsOpt.getOrElse(List())
+          Rule(
+            name.pos,
+            name.name,
+            body,
+            argsWithTypes.map(_._1.name),
+            argsWithTypes.map(_._2)
+          )
+      }
 
     lazy val Arg: Parser[(Identifier, Option[Type])] = rule(Ident ~ (COLON ~> TypeTree).?) ^^ { case id ~ tpe => (id, tpe)}
 

--- a/src/main/scala/com/github/kmizu/macro_peg/TypeChecker.scala
+++ b/src/main/scala/com/github/kmizu/macro_peg/TypeChecker.scala
@@ -1,0 +1,71 @@
+package com.github.kmizu.macro_peg
+
+import Ast._
+
+object TypeChecker {
+  case class TypeError(message: String) extends Exception(message)
+
+  private val dummy = Ast.SimpleType(Ast.DUMMY_POSITION)
+
+  def check(grammar: Grammar): Unit = {
+    val ruleTypes: Map[Symbol, Type] = grammar.rules.map { r =>
+      val paramTypes = r.argTypes.map(_.getOrElse(dummy))
+      val t: Type =
+        if (r.args.isEmpty) SimpleType(r.pos)
+        else RuleType(r.pos, paramTypes, dummy)
+      r.name -> t
+    }.toMap
+
+    grammar.rules.foreach { rule =>
+      val env = ruleTypes ++ rule.args.zip(rule.argTypes.map(_.getOrElse(dummy)))
+      val bodyType = infer(rule.body, env)
+      bodyType match {
+        case _: RuleType =>
+          throw TypeError(s"rule ${rule.name} returns function")
+        case _ =>
+      }
+    }
+  }
+
+  private def infer(exp: Expression, env: Map[Symbol, Type]): Type = exp match {
+    case Sequence(_, l, r) => infer(l, env); infer(r, env); dummy
+    case Alternation(_, l, r) => infer(l, env); infer(r, env); dummy
+    case Repeat0(_, b) => infer(b, env); dummy
+    case Repeat1(_, b) => infer(b, env); dummy
+    case Optional(_, b) => infer(b, env); dummy
+    case AndPredicate(_, b) => infer(b, env); dummy
+    case NotPredicate(_, b) => infer(b, env); dummy
+    case Debug(_, b) => infer(b, env); dummy
+    case StringLiteral(_, _) => dummy
+    case Wildcard(_) => dummy
+    case CharSet(_, _, _) => dummy
+    case CharClass(_, _, _) => dummy
+    case Identifier(_, name) => env.getOrElse(name, dummy)
+    case Function(_, args, body) =>
+      val env2 = env ++ args.map(_ -> dummy)
+      infer(body, env2)
+      RuleType(Ast.DUMMY_POSITION, List.fill(args.length)(dummy), dummy)
+    case Call(_, name, params) =>
+      env.get(name) match {
+        case Some(rt@RuleType(_, paramTypes, resultType)) =>
+          if (paramTypes.length != params.length)
+            throw TypeError(s"arity mismatch in call to $name")
+          params.zip(paramTypes).foreach { case (arg, pt) =>
+            val at = infer(arg, env)
+            (pt, at) match {
+              case (_: SimpleType, _: SimpleType) =>
+              case (_: RuleType, _: RuleType) =>
+              case (_: SimpleType, _: RuleType) =>
+                throw TypeError(s"expected simple argument for $name")
+              case (_: RuleType, _: SimpleType) =>
+                throw TypeError(s"expected function argument for $name")
+            }
+          }
+          resultType
+        case Some(_: SimpleType) =>
+          throw TypeError(s"$name is not a function")
+        case None =>
+          throw TypeError(s"undefined reference to $name")
+      }
+  }
+}

--- a/src/test/scala/com/github/kmizu/macro_peg/HigherOrderEvalSpec.scala
+++ b/src/test/scala/com/github/kmizu/macro_peg/HigherOrderEvalSpec.scala
@@ -1,0 +1,22 @@
+package com.github.kmizu.macro_peg
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.diagrams.Diagrams
+import com.github.kmizu.macro_peg.EvaluationResult.Success
+
+class HigherOrderEvalSpec extends AnyFunSpec with Diagrams {
+  describe("Higher order macro evaluation") {
+    it("evaluates nested function calls") {
+      val grammar = Parser.parse(
+        """
+          |S = Double(Plus1, "aa") !.;
+          |Plus1(s: ?) = s s;
+          |Double(f: (?) -> ?, s: ?) = f(f(s));
+        """.stripMargin)
+      TypeChecker.check(grammar)
+      val evaluator = Evaluator(grammar)
+      val result = evaluator.evaluate("aaaaaaaa", Symbol("S"))
+      assert(result == Success(""))
+    }
+  }
+}

--- a/src/test/scala/com/github/kmizu/macro_peg/HigherOrderParserSpec.scala
+++ b/src/test/scala/com/github/kmizu/macro_peg/HigherOrderParserSpec.scala
@@ -1,0 +1,21 @@
+package com.github.kmizu.macro_peg
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.diagrams.Diagrams
+
+class HigherOrderParserSpec extends AnyFunSpec with Diagrams {
+  describe("Parser with typed arguments") {
+    it("captures argument types") {
+      val grammar = Parser.parse(
+        """
+          |S = Double(Plus1, "aa") !.;
+          |Plus1(s: ?) = s s;
+          |Double(f: ?, s: ?) = f(f(s));
+        """.stripMargin)
+      val doubleRule = grammar.rules.find(_.name == Symbol("Double")).get
+      assert(doubleRule.argTypes.nonEmpty)
+      assert(doubleRule.argTypes.size == 2)
+      assert(doubleRule.argTypes.forall(_.isDefined))
+    }
+  }
+}

--- a/src/test/scala/com/github/kmizu/macro_peg/TypeCheckerSpec.scala
+++ b/src/test/scala/com/github/kmizu/macro_peg/TypeCheckerSpec.scala
@@ -1,0 +1,30 @@
+package com.github.kmizu.macro_peg
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.diagrams.Diagrams
+
+class TypeCheckerSpec extends AnyFunSpec with Diagrams {
+  describe("TypeChecker") {
+    it("rejects mismatched argument types") {
+      val grammar = Parser.parse(
+        """
+          |S = Double(Plus1, "aa") !.;
+          |Plus1(s: ?) = s s;
+          |Double(f: ?, s: ?) = f(f(s));
+        """.stripMargin)
+      assertThrows[TypeChecker.TypeError] {
+        TypeChecker.check(grammar)
+      }
+    }
+
+    it("accepts correct function argument") {
+      val grammar = Parser.parse(
+        """
+          |S = Double(Plus1, "aa") !.;
+          |Plus1(s: ?) = s s;
+          |Double(f: (?) -> ?, s: ?) = f(f(s));
+        """.stripMargin)
+      TypeChecker.check(grammar)
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `TypeChecker` to infer simple vs function types and check rule calls
- test the type checker on valid and invalid higher‑order macros
- add evaluation test for nested macro calls

## Testing
- `sbt test`