### PR TITLE
Add lambda spec

### DIFF
--- a/src/test/scala/com/github/kmizu/macro_peg/LambdaEvalSpec.scala
+++ b/src/test/scala/com/github/kmizu/macro_peg/LambdaEvalSpec.scala
@@ -1,0 +1,23 @@
+package com.github.kmizu.macro_peg
+
+import com.github.kmizu.macro_peg.EvaluationResult.{Success, Failure}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.diagrams.Diagrams
+
+class LambdaEvalSpec extends AnyFunSpec with Diagrams {
+  describe("Lambda expression evaluation") {
+    it("applies lambda as macro argument") {
+      val grammar = Parser.parse(
+        """S = Double((x -> x x), "aa") !.;
+          |Double(f: ?, s: ?) = f(f(s));
+        """.stripMargin)
+      val expanded = MacroExpander.expandGrammar(grammar)
+      val evaluator = Evaluator(expanded)
+      val resultSuccess = evaluator.evaluate("aaaaaaaa", Symbol("S"))
+      val resultFailure = evaluator.evaluate("aaaa", Symbol("S"))
+      assert(resultSuccess == Success(""))
+      assert(resultFailure == Failure)
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- add test covering lambda expressions in Macro PEG

## Testing
- `sbt -no-colors "testOnly com.github.kmizu.macro_peg.LambdaEvalSpec"`
- `sbt -no-colors test`
