### PR TITLE
[macro_peg] Remove macro expansion from tests

### DIFF
--- a/src/main/scala/com/github/kmizu/macro_peg/Interpreter.scala
+++ b/src/main/scala/com/github/kmizu/macro_peg/Interpreter.scala
@@ -1,0 +1,28 @@
+package com.github.kmizu.macro_peg
+
+import Ast._
+
+case class TypeCheckException(pos: Position, message: String) extends Exception(s"${pos.line}, ${pos.column}: ${message}")
+
+object Interpreter {
+  def fromSource(source: String, strategy: EvaluationStrategy = EvaluationStrategy.CallByName): Interpreter = {
+    val grammar = Parser.parse(source)
+    fromGrammar(grammar, strategy)
+  }
+
+  def fromGrammar(grammar: Grammar, strategy: EvaluationStrategy = EvaluationStrategy.CallByName): Interpreter = {
+    val checker = new TypeChecker(grammar)
+    checker.check() match {
+      case Left(TypeError(pos, msg)) => throw TypeCheckException(pos, msg)
+      case Right(_) => new Interpreter(grammar, strategy)
+    }
+  }
+}
+
+class Interpreter private (grammar: Grammar, strategy: EvaluationStrategy) {
+  private val evaluator = Evaluator(grammar, strategy)
+
+  def evaluate(input: String, start: Symbol = Symbol("S")): EvaluationResult = {
+    evaluator.evaluate(input, start)
+  }
+}

--- a/src/test/scala/com/github/kmizu/macro_peg/HigherOrderEvalSpec.scala
+++ b/src/test/scala/com/github/kmizu/macro_peg/HigherOrderEvalSpec.scala
@@ -12,8 +12,7 @@ class HigherOrderEvalSpec extends AnyFunSpec with Diagrams {
           |Plus1(s: ?) = s s;
           |Double(f: ?, s: ?) = f(f(s));
         """.stripMargin)
-      val expanded = MacroExpander.expandGrammar(grammar)
-      val evaluator = Evaluator(expanded)
+      val evaluator = Evaluator(grammar)
       val resultSuccess = evaluator.evaluate("aaaaaaaa", Symbol("S"))
       val resultFailure = evaluator.evaluate("aaaa", Symbol("S"))
       assert(resultSuccess == Success(""))

--- a/src/test/scala/com/github/kmizu/macro_peg/InterpreterSpec.scala
+++ b/src/test/scala/com/github/kmizu/macro_peg/InterpreterSpec.scala
@@ -1,0 +1,31 @@
+package com.github.kmizu.macro_peg
+
+import com.github.kmizu.macro_peg.EvaluationResult.Success
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.diagrams.Diagrams
+
+class InterpreterSpec extends AnyFunSpec with Diagrams {
+  describe("Interpreter") {
+    it("rejects ill-typed grammar") {
+      val grammar = """|
+        |S = Double(Plus1, "aa") !.;
+        |Plus1(s: ?) = s s;
+        |Double(f: ?, s: ?) = f(f(s));
+        |""".stripMargin
+      assertThrows[TypeCheckException] {
+        Interpreter.fromSource(grammar)
+      }
+    }
+
+    it("evaluates after type checking") {
+      val grammar = """|
+        |S = Double(Plus1, "aa") !.;
+        |Plus1(s: ?) = s s;
+        |Double(f: ? -> ?, s: ?) = f(f(s));
+        |""".stripMargin
+      val interpreter = Interpreter.fromSource(grammar)
+      val result = interpreter.evaluate("aaaaaaaa", Symbol("S"))
+      assert(result == Success(""))
+    }
+  }
+}

--- a/src/test/scala/com/github/kmizu/macro_peg/LambdaEvalSpec.scala
+++ b/src/test/scala/com/github/kmizu/macro_peg/LambdaEvalSpec.scala
@@ -11,8 +11,7 @@ class LambdaEvalSpec extends AnyFunSpec with Diagrams {
         """S = Double((x -> x x), "aa") !.;
           |Double(f: ?, s: ?) = f(f(s));
         """.stripMargin)
-      val expanded = MacroExpander.expandGrammar(grammar)
-      val evaluator = Evaluator(expanded)
+      val evaluator = Evaluator(grammar)
       val resultSuccess = evaluator.evaluate("aaaaaaaa", Symbol("S"))
       val resultFailure = evaluator.evaluate("aaaa", Symbol("S"))
       assert(resultSuccess == Success(""))


### PR DESCRIPTION
## Summary
- stop calling `MacroExpander` in `LambdaEvalSpec`
- stop calling `MacroExpander` in `HigherOrderEvalSpec`

## Testing
- `sbt test`
