### PR TITLE
[macro_peg] Hide MacroExpander behind interpreter

### DIFF
--- a/src/main/scala/com/github/kmizu/macro_peg/Interpreter.scala
+++ b/src/main/scala/com/github/kmizu/macro_peg/Interpreter.scala
@@ -11,10 +11,11 @@ object Interpreter {
   }
 
   def fromGrammar(grammar: Grammar, strategy: EvaluationStrategy = EvaluationStrategy.CallByName): Interpreter = {
-    val checker = new TypeChecker(grammar)
+    val expanded = MacroExpander.expandGrammar(grammar)
+    val checker = new TypeChecker(expanded)
     checker.check() match {
       case Left(TypeError(pos, msg)) => throw TypeCheckException(pos, msg)
-      case Right(_) => new Interpreter(grammar, strategy)
+      case Right(_) => new Interpreter(expanded, strategy)
     }
   }
 }

--- a/src/test/scala/com/github/kmizu/macro_peg/HigherOrderReturnSpec.scala
+++ b/src/test/scala/com/github/kmizu/macro_peg/HigherOrderReturnSpec.scala
@@ -1,0 +1,19 @@
+package com.github.kmizu.macro_peg
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.diagrams.Diagrams
+
+class HigherOrderReturnSpec extends AnyFunSpec with Diagrams {
+  describe("TypeChecker for higher-order return") {
+    it("infers returned function types") {
+      val grammar = Parser.parse(
+        """|
+          |S = Apply(Baz((x -> x)), "a") !.;
+          |Baz(f: ? -> ?) = f;
+          |Apply(f: ? -> ?, s: ?) = f(s);
+          |""".stripMargin)
+      val checker = new TypeChecker(grammar)
+      assert(checker.check().isRight)
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- expand grammar inside `Interpreter.fromGrammar`

## Testing
- `sbt test`
