### PR TITLE
[macro_peg] Improve Ruby parser coverage and recursion diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,3 +111,69 @@ PRタイトルのフォーマット：`[<project_name_>] <タイトル>`
 - `-> as do ... end` の lambda literal を `LambdaLiteral` AST として追加し、`add_assertion testsrc, -> as do ... end` を通過可能にした。加えて keyword parameter（`timeout: ...`）と特殊グローバル `$?` も対応。
 - `sleep 0.1` で詰まっていたため `FloatLiteral` を導入。postfix `while/until` を statement 全体へ適用できるようにして `end while true` も受理するよう拡張した。
 - 検証結果は `RubySubsetParserSpec` 98テスト + `sbt test` 全体151テスト全パス。full corpus は `24.92% (75/301)` から `26.91% (81/301)` へ改善（+6）。`runner.rb` は構文的には通るが `timeout=1000ms` では約1.05秒で依然 timeout。
+- 次の掘りで `parse.y` を見直しつつ、`Dir[glob_pattern, base: BASE]` のような bracket call 引数（keyword label含む）を parser に追加。
+- `def method_missing(name, *)` 用に nameless rest parameter（`*` / `**`）を formal parameter で受理。
+- `items[1..]` / `items[..limit]` みたいな open-ended range を追加し、`0...0x100` が `..` に先食いされる不具合を `rangeOp` の優先順（`...` 先）で修正。
+- 配列要素の splat（`[*head, 1]`）を受理するため `arrayElementExpr` を導入。
+- 回帰として `RubySubsetParserSpec` に上記ケースのテストを追加し、`testOnly com.github.kmizu.macro_peg.ruby.RubySubsetParserSpec` は全117件成功を維持。
+- full corpus (`RubyCorpusRunner`, timeout=1000ms) は timeout 依存の揺れが大きく、今回は速度改善まで届かず。次段は `parse.y` の statement/command 分岐を再照合しつつ、`runner.rb` / `parse_test.rb` 系の timeout 原因を構文単位で分割して潰す方針。
+- 途中経過を `AGENTS.md` に随時残す運用を再確認して、このセッション分も追記しながら進行。
+- 連続文字列リテラル連結（`"a" "b"`）を parser に追加。`RubySubsetParserSpec` に `parses adjacent string literals as one argument` を追加。
+- ternary と symbol literal の曖昧性を修正。`part ? part.unescaped : "1"` が `part.unescaped :"1"` と誤解釈される経路を、`symbolLiteral` の `:` 後スペース禁止（`symbolPrefix` 導入）で解消。
+- これにより `test/prism/heredoc_dedent_test.rb` の失敗（`node.parts.map { ... ? ... : "1" }`）を解消し、単体実行で成功を確認。
+- block suffix の誤バックトラック抑制のため `blockAttachSuffix` に block 開始 lookahead（`do` / `{`）を追加して失敗位置の診断を改善。
+- 検証は `sbt test` 全 `173` テスト成功、`RubySubsetParserSpec` 全 `120` テスト成功を確認。
+- full corpus 再計測（timeout=1000ms）は `21.59% (65/301)`。`bootstraptest/runner.rb` は依然 `BT = Class.new(bt) do` 近辺で `expected end`/timeout が残っており、次段の掘り対象として継続。
+- `parse.y` を再確認して、`primary` が `tLPAREN compstmt ')'` を受理する構造（括弧内で modifier 付き式が来る）を踏まえ、`parenExpr` の不足を特定。
+- `exprPostfixModifierSuffix` / `exprWithPostfixModifier` を追加し、`(expr if cond)` / `(expr unless cond)` / `(expr while cond)` / `(expr until cond)` を括弧内式として受理できるよう拡張。
+- 回帰テスト `parses parenthesized postfix if expression in splat array element` を追加。最小失敗片 `x = [*((params.rest.name || :*) if ...)]` が成功に反転。
+- `test/prism/locals_test.rb` 単体（timeout=10000ms）が `success=1/1` に改善し、`sbt test` 全 `174` テストも成功。
+- full corpus 再計測（timeout=1000ms）は `22.59% (68/301)` で前回 `21.59% (65/301)` から `+3`。一方で `bootstraptest/runner.rb` は引き続き `expected end`（`BT = Class.new(bt) do` 近辺）で未解消。
+- `runner.rb` をセグメント分割して再計測し、ボトルネックを `647-791` 行（`assert_normal_exit` / `assert_finish` 周辺）に絞り込み。特に `assert_normal_exit` 単体（`702-750`）で `timeout=10000ms` を再現。
+- さらに最小化すると、`assert_normal_exit` の前半（IO起動〜join）は通る一方、後半のネストした条件分岐と `!~` 正規表現判定を含む塊を足した時に探索が急増する傾向を確認。次段はこの領域の曖昧性を `parse.y` の `arg/stmt` 優先順に合わせて削る方針。
+- コウタから「`compaction` 後に忘れないよう、途中経過は随時 `AGENTS.md` に書く」方針を改めて指示された。以降もこの運用を継続する。
+- コウタから「一気に coverage を上げる作戦」を求められたので、次サイクルは `parse.y` 照合ベースの高収益バンドル実装で進める。
+- 優先は「未対応構文の追加」より先に「timeout 減（探索爆発抑制）」を置く。`assert_normal_exit` 系の hotspot に `cut`/先読みでコミット点を作り、1s枠での corpus 完走率を先に引き上げる。
+- 実装は 1 機能ずつではなく、同じ失敗クラスタに効くセット（例: 正規表現条件式 + modifier + brace block 周辺）をまとめ打ちして、1コミットあたりの成功ファイル増分を最大化する。
+
+### 2026-03-05
+- コウタから「timeout は探索爆発より nullable 規則の再帰呼び出し（`A(pos=1)` の再出現）を先に疑うべき」という指針をもらって、実装の中心をそこに切り替えた。
+- `MacroParsers` に `guard(name)(parser)` を追加し、同一 `(rule,pos)` の無消費再入を検出して `ParseFailure` に落とす仕組みを導入した。`RUBY_PARSER_TRACE_RECURSION` / `RUBY_PARSER_TRACE_PATH` / `RUBY_PARSER_RECURSION_HARD_FAIL` も利用可能にした。
+- 回帰テストとして `MacroParsersAdvancedSpec` に direct/indirect な non-consuming recursion 検出ケースを追加した。
+- Ruby 側では `statement` / `blockStatementsUntil` / `ifTail` に `guard` を適用し、nullable 再帰のホットスポットに直接ガードを入れた。
+- `x = case ... end` の式文脈受理を戻すため、`primaryNoCall` に `caseStmt`（加えて `unlessStmt`）を式として取り込んだ。
+- `while (node = queue.shift); return node if node; end` が落ちる回帰を修正。`node if ...` が command-style call の引数として `if ... end` を誤吸収する経路を、`commandArgHeadGuard`（`if/unless/while/...` 始まりを command 引数先頭として拒否）で遮断した。
+- `RubyCorpusRunner` を拡張して `RUBY_CORPUS_FAIL_OUT` / `RUBY_CORPUS_CLUSTER` / `RUBY_CORPUS_PROFILE` を追加し、失敗TSV出力・クラスタ集計・遅延上位表示ができるようにした。
+- `RubyCorpusRunner` の timeout 実装も見直し、worker thread を使ったタイムアウト処理（interrupt + 最終手段 stop）に変更して、計測時の積み残し抑制を試した。
+- 検証は `sbt test` 全 `193` テスト成功。full corpus の 5s 完走計測はこの時点で長時間化が残り、改善途中として継続する。
+- full corpus の 5s 完走を再計測し、`45.51% (137/301)` に到達して当面の停止条件（45%）を超えた。
+- 追加サイクルで `return if ...` と `if ...` 式競合を整理。`return` の値パースに postfix modifier 先頭ガードを入れ、`commandArgHeadGuard` も `if/unless/while/until/rescue` のみに絞った。
+- さらに `do ... rescue ... end`（block 内 rescue 節）を parser に追加し、`encodings_test.rb` の失敗を単体で成功へ反転させた。
+- サブセット再計測（`RUBY_CORPUS_MAX_FILES=60`, timeout=5000ms）は `75.00% (45/60)` から `80.00% (48/60)` に改善。
+- コウタから「5秒超えは文法バグ前提」「HARD_FAIL/guardを過信しないで進める」と再確認を受けて、`/tmp/ruby_corpus_fail_full_5s_after.tsv` の上位 fail 群を基準に再攻略した。
+- `assert_equal (+\"ア\").force_encoding(...), slice` が `functionCall` に先食いされる不具合を修正（`functionCall` を no-space 前提化）し、回帰テスト `parses command-style call with parenthesized first arg and trailing args` を追加。
+- `class_node` を `class` に誤分割する問題を、bare/receiver keyword method の単語境界化（`!identCont`）で修正。`method_node = class_node.body.body.first` の回帰テストを追加。
+- `while iseq = queue.shift` 用に condition で代入式を受理（`conditionAssignExpr` 追加）。`while` の unparenthesized assignment 条件テストを追加。
+- heredoc 正規化で `#{` が補間実行される副作用を修正（`encodeDoubleQuoted` で `\#{` へエスケープ）。`lex_test` / `comments_test` 系の失敗改善に効いた。
+- `... ||\\n!expr` を通すため、`||`/`&&` の改行継続を許可する `infixLogicalSymbol` を導入し、`parses multiline || continuation with unary rhs` を追加。
+- これで `test/prism/lex_test.rb` / `newline_test.rb` / `result/comments_test.rb` / `result/overlap_test.rb` は失敗から通過に反転。
+- 5s fail 上位20本は `8/20` から `13/20` に改善。残りは `bootstraptest/runner.rb` の parse_error 1件と timeout 6件（`test_yjit*`, `regular_expression_encoding_test.rb`, `errors_test.rb`, `source_location_test.rb`）。
+- timeout クラスタの最小化も実施し、`regular_expression_encoding_test.rb` の hotspot が nested `do` 内の `assert_regular_expression_encoding_flags(..., regexp_sources.product([...]))` 周辺で再現することを確認。
+- 安全性優先で性能最適化の試行（広すぎる cut）は回帰を起こしたため巻き戻し、最終的に安定版へ戻して `sbt test` 全件成功を維持。
+- 続きで「guardが全Ruleに無い前提」を受け、`MacroParsers.ReferenceParser` 側にも再帰検知を入れて、`refer(...)` 経由の無限再帰を rule個別guardなしで捕捉できるようにした。
+- さらに `RUBY_PARSER_VISIT_THRESHOLD` を追加し、同一 `(rule,pos)` の過剰再訪を hard fail できる診断を導入。`TRACE_PATH=1` 時は path 付きで出力するようにした。
+- 性能面では `MemoParser`（`parser.memo`）を実装し、Ruby 側の `expr` / `conditionExpr` / `commandExpr` / `postfix*` / `chainedCallExpr` に適用。`MacroParsersAdvancedSpec` に memo 回帰テストを追加。
+- `callArgs` / `bracketCallArgs` に `(` / `[` 後の `cut` を入れて、`f(...` を途中失敗したときに「引数なし call」へ戻る再探索を抑制した。
+- `regular_expression_encoding_test.rb` の timeout を解消（単体で 5s timeout -> 約0.7s）。最小再現片も約3.8s -> 約0.3s まで短縮。
+- 5s fail 上位20本の再計測は `13/20` から `15/20` へ改善（+2）。残りは `runner.rb` parse_error 1件と timeout 4件（`test_yjit*` 3件 + `source_location_test.rb` 1件）。
+- `source_location_test.rb` は単体だと約1.6sで通る一方、top20連続実行ではGC圧で timeout になる揺れを確認（runner出力にGC警告あり）。
+- 検証は `sbt test` 全 `212` テスト成功を確認。
+- ここから coverage 引き上げの追加バンドルを実装:
+  - `%w/%W/%i/%I` の quote delimiter（`%w"..."`, `%w'...'`）を追加
+  - `a = b = c` 連鎖代入の RHS を受理
+  - `*a = ...` / `ENV[n0], e0 = ...` を含む multi-assign を拡張
+  - `o&.x = 6` の safe-nav assignment、`def `(command)`、`?a` 文字リテラル、`:'@'` symbol、`{**a}` hash splat を追加
+  - `&method(:sleep).to_proc` のような call-chain block pass を受理
+  - `case ... in ...` の `in` 節、`for x,y in ...` 複数束縛、`class << o; ...; end.class_eval ...` の chain を追加
+- 回帰テストを `RubySubsetParserSpec` に大量追加（`170` 件まで拡張）し、`sbt test` 全 `228` テスト成功を確認。
+- full corpus（timeout=5000ms）は揺れがあるものの、ピークで `65.45% (197/301)`、直近再計測で `64.12% (193/301)`。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,19 @@ PRタイトルのフォーマット：`[<project_name_>] <タイトル>`
 - `wn > 0 ? wn : 1024` 向けに三項演算子を追加。性能回帰を避けるため、`conditionalExpr` は再パースを避ける左因子化実装にした。
 - `timeout&.*(timeout_scale)` のために safe navigation `&.` と演算子メソッド suffix（`*` など）を追加。対応ケースを `RubySubsetParserSpec` へ追加済み。
 - 回帰確認として `sbt test` 全パス、corpus は最新で `24.25% (73/301)`。`bootstraptest/runner.rb` は依然 `BT = Class.new(bt) do ...` 起点で失敗しており、次の掘りポイントとして継続調査中。
+
+### 2026-03-04
+- コウタから「根本的にカバレッジを上げる」「節目で `parse.y` も見て全体構造を把握する」という方針をもらって、まず `parse.y` の `stmt/expr/command/arg/primary/lambda` を再確認してから対応順を決めた。
+- `commandArgs` 周りの回帰（`spacing` を広く取りすぎることでバックトラックが増える問題）を修正して、corpus 成功率を `22.92% (69/301)` から `25.58% (77/301)` に戻した。
+- その後、literal と演算系をまとめて底上げした：
+  - `%i/%I` symbol array
+  - 基数付き・アンダースコア付き整数（`0b/0o/0d/0x`, `1_000`）
+  - `IntLiteral` を `BigInt` 化して巨大整数での `NumberFormatException` を解消
+  - `**`, `&`, `|`, `^`, `~`, `===`, `<=>` などの式演算を拡張
+  - 演算子/サフィックス付き symbol literal（`:!=`, `:<=`, `:frozen?`）と補間付き symbol（`:"test_#{path}"`）を追加
+- `kw(...)` の単語境界不足で `define_method` を `def` と誤認する根本バグを修正（`<~ !identCont`）。`do ... end` の `end` 吸い込みが減り、`dump_test.rb` などの落ち方を改善。
+- `name:` と `::` の競合（`Test::Unit` を keyword label 誤認）を `labelColon` で分離し、deep const path 引数（`extend Test::Unit::Assertions`）を通るようにした。
+- 最終的に `sbt test` は全 `165` テスト成功、corpus は `27.91% (84/301)` まで改善（前回 `24.25%` から `+11` ファイル）。
 - `runner.rb` 掘りの続きとして、`BT = ...` 定数代入を追加しつつ、誤爆しないように `constAssignStmt` を `=` 先読み付きに修正。`BT.tty = ... if ...` のような定数receiver代入も回帰テストで固定した。
 - heredoc前処理を `<<~` だけでなく `<<-` / `<<ID` まで拡張し、dash heredoc の回帰テストを追加。`not` 単項演算子、`nil?` のような予約語ベースpunctuated method 受理、`[]` への `=`/`||=` も対応した。
 - 補間付きダブルクォート文字列（`#{...}` 内に `"` を含むケース）と backtick 文字列（`` `...` ``）を追加。`writer.write_object({...})` 向けに multiline hash entry の改行処理も修正した。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,3 +85,11 @@ PRタイトルのフォーマット：`[<project_name_>] <タイトル>`
 - `wn > 0 ? wn : 1024` 向けに三項演算子を追加。性能回帰を避けるため、`conditionalExpr` は再パースを避ける左因子化実装にした。
 - `timeout&.*(timeout_scale)` のために safe navigation `&.` と演算子メソッド suffix（`*` など）を追加。対応ケースを `RubySubsetParserSpec` へ追加済み。
 - 回帰確認として `sbt test` 全パス、corpus は最新で `24.25% (73/301)`。`bootstraptest/runner.rb` は依然 `BT = Class.new(bt) do ...` 起点で失敗しており、次の掘りポイントとして継続調査中。
+- `runner.rb` 掘りの続きとして、`BT = ...` 定数代入を追加しつつ、誤爆しないように `constAssignStmt` を `=` 先読み付きに修正。`BT.tty = ... if ...` のような定数receiver代入も回帰テストで固定した。
+- heredoc前処理を `<<~` だけでなく `<<-` / `<<ID` まで拡張し、dash heredoc の回帰テストを追加。`not` 単項演算子、`nil?` のような予約語ベースpunctuated method 受理、`[]` への `=`/`||=` も対応した。
+- 補間付きダブルクォート文字列（`#{...}` 内に `"` を含むケース）と backtick 文字列（`` `...` ``）を追加。`writer.write_object({...})` 向けに multiline hash entry の改行処理も修正した。
+- `do ... ensure ... end` / `def ... ensure ... end` の bare ensure を `BeginRescue(..., ensureBody=...)` へ正規化する形で実装。加えて `faildesc, t = super` 用に `MultiAssign` AST+parser、`&:kill` の symbol block-pass、bare def params、`*args` / `**opts` と call 側 splat も追加した。
+- `(@count += 1)` のような式文脈での複合代入を `AssignExpr` 化して通過。`sbt test` は全件成功を維持した一方、full corpus は今回再計測でも `24.25% (73/301)` のままで、`bootstraptest/runner.rb` / `part_after_main` は未対応構文（class `Assertion` 周辺）で引き続き詰まっている。
+- 続きで `BT.columns > 0` / `e and BT.columns > 0` が落ちる回帰を修正。演算子前空白の扱いを見直し、`RubySubsetParserSpec` に比較式・`and` 連鎖の回帰テストを追加した。
+- `puts tests.map {|path| File.basename(path) }.inspect` のような「空白あり brace-block suffix + chain」を通すため、`blockAttachSuffix` の空白吸収と `braceBlock` の閉じ波括弧手前空白を対応。関連テスト（command arg / `Thread.new{ r.read }`）を追加。
+- `sbt test` と `RubySubsetParserSpec` は全パス維持。ただし full corpus は現時点で `21.26% (64/301, timeout=1000ms)` まで低下しており、`runner.rb` は依然 timeout。性能回帰と `class Assertion` 以降の解析継続が次タスク。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,3 +93,8 @@ PRタイトルのフォーマット：`[<project_name_>] <タイトル>`
 - 続きで `BT.columns > 0` / `e and BT.columns > 0` が落ちる回帰を修正。演算子前空白の扱いを見直し、`RubySubsetParserSpec` に比較式・`and` 連鎖の回帰テストを追加した。
 - `puts tests.map {|path| File.basename(path) }.inspect` のような「空白あり brace-block suffix + chain」を通すため、`blockAttachSuffix` の空白吸収と `braceBlock` の閉じ波括弧手前空白を対応。関連テスト（command arg / `Thread.new{ r.read }`）を追加。
 - `sbt test` と `RubySubsetParserSpec` は全パス維持。ただし full corpus は現時点で `21.26% (64/301, timeout=1000ms)` まで低下しており、`runner.rb` は依然 timeout。性能回帰と `class Assertion` 以降の解析継続が次タスク。
+- `runner.rb` 再攻略で、`def ... rescue/else/ensure ... end` を `defStmt` 側でも正式対応。さらに postfix `rescue` modifier（`r.close rescue nil`）と `%` 二項演算子を追加して、`with_stderr` / `show_progress` 周辺の詰まりを解消した。
+- `blockStatementsUntil` を再帰型に作り直して、複数 `rescue` 節で改行をまたぐケースを安定化。`def f ... rescue E1 ... rescue E2 ...` の回帰テストを追加した。
+- `-> as do ... end` の lambda literal を `LambdaLiteral` AST として追加し、`add_assertion testsrc, -> as do ... end` を通過可能にした。加えて keyword parameter（`timeout: ...`）と特殊グローバル `$?` も対応。
+- `sleep 0.1` で詰まっていたため `FloatLiteral` を導入。postfix `while/until` を statement 全体へ適用できるようにして `end while true` も受理するよう拡張した。
+- 検証結果は `RubySubsetParserSpec` 98テスト + `sbt test` 全体151テスト全パス。full corpus は `24.92% (75/301)` から `26.91% (81/301)` へ改善（+6）。`runner.rb` は構文的には通るが `timeout=1000ms` では約1.05秒で依然 timeout。

--- a/src/main/scala/com/github/kmizu/macro_peg/combinator/MacroParsers.scala
+++ b/src/main/scala/com/github/kmizu/macro_peg/combinator/MacroParsers.scala
@@ -1,10 +1,27 @@
 package com.github.kmizu.macro_peg.combinator
 
+import scala.collection.mutable.ArrayBuffer
 import scala.collection.mutable.ListBuffer
+import scala.collection.mutable.HashMap
+import java.util.concurrent.atomic.AtomicInteger
 
 object MacroParsers {
   type Input = String
   case class ~[+A, +B](_1: A, _2: B)
+
+  private final case class RecursionFrame(rule: String, remaining: Int)
+  private final class RecursionContext(val inputLength: Int) {
+    val stack: ArrayBuffer[RecursionFrame] = ArrayBuffer.empty
+    val activeCounts: HashMap[RecursionFrame, Int] = HashMap.empty
+    val visits: HashMap[RecursionFrame, Int] = HashMap.empty
+    val memo: HashMap[(Int, Int), MemoState] = HashMap.empty
+  }
+  private sealed trait MemoState
+  private case object MemoInProgress extends MemoState
+  private final case class MemoDone(result: ParseResult[Any]) extends MemoState
+  private val recursionContextTL: ThreadLocal[RecursionContext] = new ThreadLocal[RecursionContext]()
+  private val referenceParserId: AtomicInteger = new AtomicInteger(0)
+  private val memoParserId: AtomicInteger = new AtomicInteger(0)
 
   abstract sealed class ParseResult[+T] {
     /**
@@ -75,6 +92,109 @@ object MacroParsers {
 
     /** Push trace label to failures for debugging nested parser calls. */
     def trace(name: String): MacroParser[T] = TraceParser(name, this)
+
+    /** Memoize this parser by (parser-id, input-position) within a single parse run. */
+    def memo: MacroParser[T] = MemoParser(this)
+  }
+
+  private def envEnabled(name: String): Boolean =
+    Option(System.getenv(name)).contains("1")
+
+  private def recursionRepeatThreshold: Int =
+    Option(System.getenv("RUBY_PARSER_RECURSION_THRESHOLD"))
+      .flatMap(_.toIntOption)
+      .filter(_ >= 2)
+      .getOrElse(2)
+
+  private def recursionHardFail: Boolean =
+    envEnabled("RUBY_PARSER_RECURSION_HARD_FAIL")
+
+  private def recursionTraceEnabled: Boolean =
+    envEnabled("RUBY_PARSER_TRACE_RECURSION")
+
+  private def recursionTracePathEnabled: Boolean =
+    envEnabled("RUBY_PARSER_TRACE_PATH")
+
+  private def recursionVisitThreshold: Int =
+    Option(System.getenv("RUBY_PARSER_VISIT_THRESHOLD"))
+      .flatMap(_.toIntOption)
+      .filter(_ >= 1)
+      .getOrElse(0)
+
+  private def frameOffset(ctx: RecursionContext, frame: RecursionFrame): Int =
+    ctx.inputLength - frame.remaining
+
+  private def formatCycle(ctx: RecursionContext, cycle: List[RecursionFrame]): String =
+    cycle.map { frame =>
+      s"${frame.rule}(${frameOffset(ctx, frame)})"
+    }.mkString(" -> ")
+
+  private def withRecursionFrame[T](name: String, input: Input)(body: => ParseResult[T]): ParseResult[T] = {
+    val context = recursionContextTL.get()
+    if(context == null) {
+      val previous = recursionContextTL.get()
+      recursionContextTL.set(new RecursionContext(input.length))
+      try withRecursionFrame(name, input)(body)
+      finally recursionContextTL.set(previous)
+    } else {
+      val frame = RecursionFrame(name, input.length)
+      if(recursionVisitThreshold > 0) {
+        val nextCount = context.visits.getOrElse(frame, 0) + 1
+        context.visits.update(frame, nextCount)
+        if(nextCount >= recursionVisitThreshold) {
+          val offset = frameOffset(context, frame)
+          val currentPath = formatCycle(context, context.stack.toList :+ frame)
+          val message =
+            if(recursionTracePathEnabled) {
+              s"suspicious repeated visits detected: ${name}($offset) count=$nextCount path=$currentPath"
+            } else {
+              s"suspicious repeated visits at ${name}($offset), count=$nextCount"
+            }
+          if(recursionTraceEnabled) {
+            Console.err.println(s"[macro-peg] $message")
+          }
+          return ParseFailure(
+            message = message,
+            next = input,
+            committed = recursionHardFail,
+            expected = List("rule should make progress or commit earlier")
+          )
+        }
+      }
+      val occurrences = context.activeCounts.getOrElse(frame, 0) + 1
+      if(occurrences >= recursionRepeatThreshold) {
+        val cycleStart = context.stack.lastIndexWhere(_ == frame)
+        val cycleFrames =
+          if(cycleStart >= 0) context.stack.drop(cycleStart).toList :+ frame
+          else List(frame)
+        val offset = frameOffset(context, frame)
+        val message =
+          if(recursionTracePathEnabled) {
+            s"infinite recursion detected: ${formatCycle(context, cycleFrames)}"
+          } else {
+            s"infinite recursion detected at ${name}($offset)"
+          }
+        if(recursionTraceEnabled) {
+          Console.err.println(s"[macro-peg] $message")
+        }
+        ParseFailure(
+          message = message,
+          next = input,
+          committed = recursionHardFail,
+          expected = List("non-nullable recursive rule must consume input")
+        )
+      } else {
+        context.stack += frame
+        context.activeCounts.update(frame, occurrences)
+        try body
+        finally {
+          if(context.stack.nonEmpty) context.stack.remove(context.stack.length - 1)
+          val remainingCount = context.activeCounts.getOrElse(frame, 1) - 1
+          if(remainingCount <= 0) context.activeCounts.remove(frame)
+          else context.activeCounts.update(frame, remainingCount)
+        }
+      }
+    }
   }
 
   def chainl[A](p: MacroParser[A])(q: MacroParser[(A, A) => A]): MacroParser[A] = {
@@ -104,8 +224,10 @@ object MacroParsers {
 
   def range(ranges: Seq[Char]*): RangedParser = RangedParser(ranges: _*)
   implicit def characterRangesToParser(ranges: Seq[Seq[Char]]): RangedParser = range(ranges: _*)
-  def refer[T](parser: => MacroParser[T]): ReferenceParser[T] = ReferenceParser(() => parser)
+  def refer[T](parser: => MacroParser[T]): ReferenceParser[T] = ReferenceParser(() => parser, None)
+  def refer[T](name: String, parser: => MacroParser[T]): ReferenceParser[T] = ReferenceParser(() => parser, Some(name))
   def rewritable[T](parser: MacroParser[T]): RewritableParser[T] = RewritableParser(parser)
+  def guard[T](name: String)(parser: => MacroParser[T]): GuardParser[T] = GuardParser(name, () => parser)
 
   private def consumed(input: Input, failure: ParseFailure): Int = input.length - failure.next.length
 
@@ -126,9 +248,15 @@ object MacroParsers {
   }
 
   def parseAll[T](parser: MacroParser[T], input: Input): Either[ParseFailure, T] = {
-    (parser ~ !any)(input) match {
-      case ParseSuccess(result ~ _, _) => Right(result)
-      case failure: ParseFailure => Left(failure)
+    val previous = recursionContextTL.get()
+    recursionContextTL.set(new RecursionContext(input.length))
+    try {
+      (parser ~ !any)(input) match {
+        case ParseSuccess(result ~ _, _) => Right(result)
+        case failure: ParseFailure => Left(failure)
+      }
+    } finally {
+      recursionContextTL.set(previous)
     }
   }
 
@@ -307,9 +435,48 @@ object MacroParsers {
     }
   }
 
-  final case class ReferenceParser[T](delayedParser: () => MacroParser[T]) extends MacroParser[T] {
-    override def apply(input: Input): ParseResult[T] = reference(input)
+  final case class ReferenceParser[T](delayedParser: () => MacroParser[T], debugName: Option[String]) extends MacroParser[T] {
+    private val parserId: Int = referenceParserId.incrementAndGet()
+    private lazy val frameName: String = debugName.getOrElse(s"ref#$parserId")
+
+    override def apply(input: Input): ParseResult[T] =
+      withRecursionFrame(frameName, input) {
+        reference(input)
+      }
+
     lazy val reference: MacroParser[T] = delayedParser()
+  }
+
+  final case class MemoParser[T](parser: MacroParser[T]) extends MacroParser[T] {
+    private val parserId: Int = memoParserId.incrementAndGet()
+
+    override def apply(input: Input): ParseResult[T] = {
+      val context = recursionContextTL.get()
+      if(context == null) {
+        val previous = recursionContextTL.get()
+        recursionContextTL.set(new RecursionContext(input.length))
+        try apply(input)
+        finally recursionContextTL.set(previous)
+      } else {
+        val key = (parserId, input.length)
+        context.memo.get(key) match {
+          case Some(MemoDone(result)) =>
+            result.asInstanceOf[ParseResult[T]]
+          case Some(MemoInProgress) =>
+            ParseFailure(
+              "left-recursive memoized parser invocation detected",
+              input,
+              committed = recursionHardFail,
+              expected = List("memoized parser recursion must consume input")
+            )
+          case None =>
+            context.memo.update(key, MemoInProgress)
+            val result = parser(input)
+            context.memo.update(key, MemoDone(result.asInstanceOf[ParseResult[Any]]))
+            result
+        }
+      }
+    }
   }
 
   case object AnyParser extends MacroParser[String] {
@@ -369,5 +536,12 @@ object MacroParsers {
       case success: ParseSuccess[T] => success
       case failure: ParseFailure => failure.addTrace(name)
     }
+  }
+
+  final case class GuardParser[T](name: String, delayed: () => MacroParser[T]) extends MacroParser[T] {
+    override def apply(input: Input): ParseResult[T] =
+      withRecursionFrame(name, input) {
+        delayed()(input)
+      }
   }
 }

--- a/src/main/scala/com/github/kmizu/macro_peg/ruby/RubyAst.scala
+++ b/src/main/scala/com/github/kmizu/macro_peg/ruby/RubyAst.scala
@@ -18,17 +18,20 @@ object RubyAst {
   case class MultiAssign(names: List[String], value: Expr, span: Span = UnknownSpan) extends Statement
   case class Return(value: Option[Expr], span: Span = UnknownSpan) extends Statement
   case class RescueClause(exceptionClasses: List[Expr], variable: Option[String], body: List[Statement], span: Span = UnknownSpan) extends Node
-  case class BeginRescue(body: List[Statement], rescues: List[RescueClause], elseBody: List[Statement], ensureBody: List[Statement], span: Span = UnknownSpan) extends Statement
+  case class BeginRescue(body: List[Statement], rescues: List[RescueClause], elseBody: List[Statement], ensureBody: List[Statement], span: Span = UnknownSpan) extends Expr
   case class WhenClause(patterns: List[Expr], body: List[Statement], span: Span = UnknownSpan) extends Node
   case class Retry(span: Span = UnknownSpan) extends Statement
   case class ForIn(name: String, iterable: Expr, body: List[Statement], span: Span = UnknownSpan) extends Statement
   case class Def(name: String, params: List[String], body: List[Statement], span: Span = UnknownSpan) extends Statement
   case class ClassDef(name: String, body: List[Statement], span: Span = UnknownSpan, superClass: Option[Expr] = None) extends Statement
   case class SingletonClassDef(receiver: Expr, body: List[Statement], span: Span = UnknownSpan) extends Statement
+  case class SingletonClassExpr(receiver: Expr, body: List[Statement], span: Span = UnknownSpan) extends Expr
   case class ModuleDef(name: String, body: List[Statement], span: Span = UnknownSpan) extends Statement
 
   case class IntLiteral(value: BigInt, span: Span = UnknownSpan) extends Expr
   case class FloatLiteral(value: Double, span: Span = UnknownSpan) extends Expr
+  case class RationalLiteral(value: Expr, span: Span = UnknownSpan) extends Expr
+  case class ImaginaryLiteral(value: Expr, span: Span = UnknownSpan) extends Expr
   case class StringLiteral(value: String, span: Span = UnknownSpan) extends Expr
   case class SymbolLiteral(value: String, span: Span) extends Expr
   case class BoolLiteral(value: Boolean, span: Span = UnknownSpan) extends Expr

--- a/src/main/scala/com/github/kmizu/macro_peg/ruby/RubyAst.scala
+++ b/src/main/scala/com/github/kmizu/macro_peg/ruby/RubyAst.scala
@@ -15,6 +15,7 @@ object RubyAst {
 
   case class ExprStmt(expr: Expr, span: Span = UnknownSpan) extends Statement
   case class Assign(name: String, value: Expr, span: Span = UnknownSpan) extends Statement
+  case class MultiAssign(names: List[String], value: Expr, span: Span = UnknownSpan) extends Statement
   case class Return(value: Option[Expr], span: Span = UnknownSpan) extends Statement
   case class RescueClause(exceptionClasses: List[Expr], variable: Option[String], body: List[Statement], span: Span = UnknownSpan) extends Node
   case class BeginRescue(body: List[Statement], rescues: List[RescueClause], elseBody: List[Statement], ensureBody: List[Statement], span: Span = UnknownSpan) extends Statement

--- a/src/main/scala/com/github/kmizu/macro_peg/ruby/RubyAst.scala
+++ b/src/main/scala/com/github/kmizu/macro_peg/ruby/RubyAst.scala
@@ -28,6 +28,7 @@ object RubyAst {
   case class ModuleDef(name: String, body: List[Statement], span: Span = UnknownSpan) extends Statement
 
   case class IntLiteral(value: Long, span: Span = UnknownSpan) extends Expr
+  case class FloatLiteral(value: Double, span: Span = UnknownSpan) extends Expr
   case class StringLiteral(value: String, span: Span = UnknownSpan) extends Expr
   case class SymbolLiteral(value: String, span: Span) extends Expr
   case class BoolLiteral(value: Boolean, span: Span = UnknownSpan) extends Expr
@@ -43,6 +44,7 @@ object RubyAst {
   case class Call(receiver: Option[Expr], methodName: String, args: List[Expr], span: Span = UnknownSpan) extends Expr
   case class Block(params: List[String], body: List[Statement], span: Span = UnknownSpan) extends Node
   case class CallWithBlock(call: Expr, block: Block, span: Span = UnknownSpan) extends Expr
+  case class LambdaLiteral(params: List[String], body: List[Statement], span: Span = UnknownSpan) extends Expr
   case class RangeExpr(start: Expr, end: Expr, exclusive: Boolean, span: Span = UnknownSpan) extends Expr
   case class UnaryOp(op: String, expr: Expr, span: Span = UnknownSpan) extends Expr
   case class BinaryOp(lhs: Expr, op: String, rhs: Expr, span: Span = UnknownSpan) extends Expr

--- a/src/main/scala/com/github/kmizu/macro_peg/ruby/RubyAst.scala
+++ b/src/main/scala/com/github/kmizu/macro_peg/ruby/RubyAst.scala
@@ -27,7 +27,7 @@ object RubyAst {
   case class SingletonClassDef(receiver: Expr, body: List[Statement], span: Span = UnknownSpan) extends Statement
   case class ModuleDef(name: String, body: List[Statement], span: Span = UnknownSpan) extends Statement
 
-  case class IntLiteral(value: Long, span: Span = UnknownSpan) extends Expr
+  case class IntLiteral(value: BigInt, span: Span = UnknownSpan) extends Expr
   case class FloatLiteral(value: Double, span: Span = UnknownSpan) extends Expr
   case class StringLiteral(value: String, span: Span = UnknownSpan) extends Expr
   case class SymbolLiteral(value: String, span: Span) extends Expr

--- a/src/main/scala/com/github/kmizu/macro_peg/ruby/RubyCorpusRunner.scala
+++ b/src/main/scala/com/github/kmizu/macro_peg/ruby/RubyCorpusRunner.scala
@@ -4,10 +4,8 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
-import scala.concurrent.Await
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-import scala.concurrent.duration.DurationInt
+import java.nio.file.StandardOpenOption
+import scala.collection.mutable.ArrayBuffer
 import scala.jdk.CollectionConverters._
 import scala.util.control.NonFatal
 
@@ -18,21 +16,59 @@ object RubyCorpusRunner {
     "third_party/ruby3/upstream/ruby/test/prism"
   )
 
-  private implicit val ec: ExecutionContext = ExecutionContext.global
+  private final case class FailureInfo(path: Path, reason: String, message: String, elapsedMs: Long)
+  private final case class ParseTiming(path: Path, elapsedMs: Long, status: String)
 
   private def parseWithTimeout(input: String, timeoutMs: Int): Either[String, RubyAst.Program] = {
-    try {
-      Await.result(Future(RubySubsetParser.parse(input)), timeoutMs.millis)
-    } catch {
-      case _: java.util.concurrent.TimeoutException =>
-        Left(s"timeout after ${timeoutMs}ms")
-      case NonFatal(e) =>
-        Left(s"exception: ${e.getClass.getSimpleName}: ${Option(e.getMessage).getOrElse("")}")
+    @volatile var result: Either[String, RubyAst.Program] = null
+    @volatile var thrown: Throwable = null
+    val worker = new Thread(
+      () => {
+        try {
+          result = RubySubsetParser.parse(input)
+        } catch {
+          case t: Throwable =>
+            thrown = t
+        }
+      },
+      "ruby-corpus-parser-worker"
+    )
+    worker.setDaemon(true)
+    worker.start()
+    worker.join(timeoutMs.toLong)
+
+    if(worker.isAlive) {
+      worker.interrupt()
+      worker.join(10L)
+      if(worker.isAlive) {
+        // NOTE: force-stop to prevent a timed-out parser from accumulating and poisoning corpus runs.
+        try {
+          worker.stop()
+        } catch {
+          case _: UnsupportedOperationException =>
+            ()
+        }
+      }
+      Left(s"timeout after ${timeoutMs}ms")
+    } else if(thrown != null) {
+      Left(s"exception: ${thrown.getClass.getSimpleName}: ${Option(thrown.getMessage).getOrElse("")}")
+    } else if(result == null) {
+      Left("exception: parser worker exited without a result")
+    } else {
+      result
     }
   }
 
   private def firstLine(message: String): String =
     message.linesIterator.nextOption().getOrElse(message)
+
+  private def classifyFailure(message: String): String =
+    if(message.startsWith("timeout after")) "timeout"
+    else if(message.startsWith("exception:")) "exception"
+    else "parse_error"
+
+  private def normalizeFailureKey(failure: FailureInfo): String =
+    s"${failure.reason}: ${firstLine(failure.message).replaceAll("\\s+", " ").trim}"
 
   private def collectRubyFiles(roots: List[Path]): List[Path] =
     roots.flatMap { root =>
@@ -48,8 +84,8 @@ object RubyCorpusRunner {
     val roots =
       if(args.nonEmpty) args.toList.map(Paths.get(_))
       else defaultRoots.map(Paths.get(_))
-    val files = collectRubyFiles(roots)
-    if(files.isEmpty) {
+    val allFiles = collectRubyFiles(roots)
+    if(allFiles.isEmpty) {
       println("No .rb files found. Pass roots as args or fetch Ruby corpus into third_party/ruby3/upstream/ruby.")
       return
     }
@@ -58,24 +94,41 @@ object RubyCorpusRunner {
     val timeoutMs = sys.env.get("RUBY_CORPUS_TIMEOUT_MS").flatMap(v => v.toIntOption).getOrElse(1000)
     val sampleLimit = sys.env.get("RUBY_CORPUS_FAIL_SAMPLES").flatMap(v => v.toIntOption).getOrElse(20)
     val fullError = sys.env.get("RUBY_CORPUS_FULL_ERROR").contains("1")
+    val clusterEnabled = sys.env.get("RUBY_CORPUS_CLUSTER").contains("1")
+    val profileEnabled = sys.env.get("RUBY_CORPUS_PROFILE").contains("1")
+    val profileTop = sys.env.get("RUBY_CORPUS_PROFILE_TOP").flatMap(_.toIntOption).getOrElse(20)
+    val failureOutPath = sys.env.get("RUBY_CORPUS_FAIL_OUT").map(Paths.get(_))
+    val maxFiles = sys.env.get("RUBY_CORPUS_MAX_FILES").flatMap(_.toIntOption).filter(_ > 0)
+    val files = maxFiles.map(allFiles.take).getOrElse(allFiles)
+    maxFiles.foreach { limit =>
+      println(s"RUBY_CORPUS_MAX_FILES active: using first ${files.size}/${allFiles.size} files")
+    }
 
     var success = 0
-    val failures = scala.collection.mutable.ArrayBuffer.empty[(Path, String)]
+    val failures = ArrayBuffer.empty[FailureInfo]
+    val timings = ArrayBuffer.empty[ParseTiming]
 
     files.foreach { path =>
       try {
         val source = Files.readString(path, StandardCharsets.UTF_8)
+        val fileStarted = System.nanoTime()
         parseWithTimeout(source, timeoutMs) match {
           case Right(_) =>
             success += 1
+            val elapsedMs = (System.nanoTime() - fileStarted) / 1000000
+            timings += ParseTiming(path, elapsedMs, "success")
           case Left(error) =>
-            if(failures.size < sampleLimit) failures += path -> (if(fullError) error else firstLine(error))
+            val elapsedMs = (System.nanoTime() - fileStarted) / 1000000
+            val message = if(fullError) error else firstLine(error)
+            val reason = classifyFailure(error)
+            failures += FailureInfo(path, reason, message, elapsedMs)
+            timings += ParseTiming(path, elapsedMs, reason)
         }
       } catch {
         case NonFatal(e) =>
-          if(failures.size < sampleLimit) {
-            failures += path -> s"read error: ${e.getClass.getSimpleName}: ${Option(e.getMessage).getOrElse("")}"
-          }
+          val message = s"read error: ${e.getClass.getSimpleName}: ${Option(e.getMessage).getOrElse("")}"
+          failures += FailureInfo(path, "read_error", message, elapsedMs = 0L)
+          timings += ParseTiming(path, elapsedMs = 0L, "read_error")
       }
     }
 
@@ -86,10 +139,51 @@ object RubyCorpusRunner {
 
     println(f"Ruby corpus parse result: total=$total success=$success failed=$failed success_rate=$rate%.2f%% elapsed_ms=$elapsedMs timeout_ms=$timeoutMs")
     if(failures.nonEmpty) {
-      println(s"Failure samples (first ${failures.size}):")
-      failures.foreach { case (path, error) =>
-        println(s"- ${path.toString}: $error")
+      val samples = failures.take(sampleLimit)
+      println(s"Failure samples (first ${samples.size}/${failures.size}):")
+      samples.foreach { failure =>
+        println(s"- ${failure.path.toString}: ${failure.reason}: ${failure.message}")
       }
+    }
+
+    if(clusterEnabled && failures.nonEmpty) {
+      println("Failure clusters:")
+      failures
+        .groupBy(normalizeFailureKey)
+        .view
+        .mapValues(_.size)
+        .toList
+        .sortBy { case (_, count) => -count }
+        .take(20)
+        .foreach { case (key, count) =>
+          println(s"- $count x $key")
+        }
+    }
+
+    if(profileEnabled && timings.nonEmpty) {
+      println(s"Slowest files (top ${math.min(profileTop, timings.size)}):")
+      timings
+        .sortBy(-_.elapsedMs)
+        .take(profileTop)
+        .foreach { timing =>
+          println(s"- ${timing.elapsedMs}ms\t${timing.status}\t${timing.path}")
+        }
+    }
+
+    failureOutPath.foreach { outputPath =>
+      val rows = failures.map { failure =>
+        val safeMessage = failure.message.replace('\n', ' ').replace('\t', ' ')
+        s"${failure.path}\t${failure.reason}\t${failure.elapsedMs}\t$safeMessage"
+      }
+      Files.write(
+        outputPath,
+        rows.asJava,
+        StandardCharsets.UTF_8,
+        StandardOpenOption.CREATE,
+        StandardOpenOption.TRUNCATE_EXISTING,
+        StandardOpenOption.WRITE
+      )
+      println(s"Wrote failure report: $outputPath")
     }
   }
 }

--- a/src/main/scala/com/github/kmizu/macro_peg/ruby/RubySubsetParser.scala
+++ b/src/main/scala/com/github/kmizu/macro_peg/ruby/RubySubsetParser.scala
@@ -40,6 +40,9 @@ object RubySubsetParser {
   private def token[A](parser: P[A]): P[A] =
     (parser ~ inlineSpacing).map(_._1)
 
+  private def guarded[A](name: String)(parser: => P[A]): P[A] =
+    guard(s"ruby.$name")(parser)
+
   private def kw(name: String): P[String] =
     token(string(name) <~ !identCont).label(s"`$name`")
 
@@ -48,6 +51,9 @@ object RubySubsetParser {
 
   private lazy val labelColon: P[String] =
     token(":".s <~ !":".s)
+
+  private lazy val symbolPrefix: P[String] =
+    ":".s <~ !":".s
 
   private lazy val identStart: P[String] =
     range('a' to 'z', 'A' to 'Z', '_' to '_')
@@ -113,11 +119,23 @@ object RubySubsetParser {
   private lazy val methodIdentifier: P[String] =
     token(methodIdentifierNoSpace)
 
-  private lazy val keywordMethodNameNoSpace: P[String] =
-    "class".s
+  private def keywordMethodName(name: String): P[String] =
+    string(name) <~ !identCont
+
+  private lazy val bareKeywordMethodNameNoSpace: P[String] =
+    keywordMethodName("class") /
+      keywordMethodName("private") /
+      keywordMethodName("public") /
+      keywordMethodName("protected")
+
+  private lazy val receiverKeywordMethodNameNoSpace: P[String] =
+    bareKeywordMethodNameNoSpace /
+      keywordMethodName("begin") /
+      keywordMethodName("end") /
+      keywordMethodName("for")
 
   private lazy val receiverMethodNameNoSpace: P[String] =
-    methodIdentifierNoSpace / keywordMethodNameNoSpace
+    methodIdentifierNoSpace / receiverKeywordMethodNameNoSpace
 
   private lazy val punctuatedMethodIdentifierNoSpace: P[String] =
     methodIdentifierWithSuffixRaw
@@ -140,6 +158,9 @@ object RubySubsetParser {
   private lazy val globalVarName: P[String] =
     token(
       ("$".s ~ identifierRaw).map { case _ ~ name => s"$$$name" } /
+        ("$-".s ~ range('0' to '9', 'a' to 'z', 'A' to 'Z', '_' to '_').+).map {
+          case _ ~ chars => s"$$-${chars.mkString}"
+        } /
         ("$".s ~ range('0' to '9').+).map { case _ ~ digits => s"$$${digits.mkString}" } /
         "$!".s /
         "$?".s /
@@ -194,10 +215,25 @@ object RubySubsetParser {
       ("0".s ~ ("x".s / "X".s) ~ hexDigitsRaw).map { case _ ~ _ ~ ds => ds -> 16 } /
       decimalDigitsRaw.map(_ -> 10)
 
+  private lazy val numericSuffix: P[String] =
+    "ri".s /
+      "ir".s /
+      "r".s /
+      "i".s
+
+  private def applyNumericSuffix(base: Expr, suffix: Option[String]): Expr =
+    suffix match {
+      case Some("r") => RationalLiteral(base)
+      case Some("i") => ImaginaryLiteral(base)
+      case Some("ri") => ImaginaryLiteral(RationalLiteral(base))
+      case Some("ir") => RationalLiteral(ImaginaryLiteral(base))
+      case _ => base
+    }
+
   private lazy val integerLiteral: P[Expr] =
-    token((integerLiteralRaw <~ !(".".s ~ range('0' to '9')) <~ !identCont)).map {
-      case (raw, base) =>
-        IntLiteral(BigInt(raw.replace("_", ""), base))
+    token(((integerLiteralRaw <~ !(".".s ~ range('0' to '9'))) ~ numericSuffix.?) <~ !identCont).map {
+      case (raw, base) ~ suffix =>
+        applyNumericSuffix(IntLiteral(BigInt(raw.replace("_", ""), base)), suffix)
     }
 
   private lazy val floatExponentRaw: P[String] =
@@ -216,9 +252,10 @@ object RubySubsetParser {
       }
 
   private lazy val floatLiteral: P[Expr] =
-    token((floatLiteralRaw <~ !identCont)).map { raw =>
-      val normalized = raw.replace("_", "")
-      FloatLiteral(Try(normalized.toDouble).getOrElse(Double.NaN))
+    token((floatLiteralRaw ~ numericSuffix.?) <~ !identCont).map {
+      case raw ~ suffix =>
+        val normalized = raw.replace("_", "")
+        applyNumericSuffix(FloatLiteral(Try(normalized.toDouble).getOrElse(Double.NaN)), suffix)
     }
 
   private lazy val escapedChar: P[String] =
@@ -315,8 +352,25 @@ object RubySubsetParser {
       case _ ~ body => StringLiteral(body)
     })
 
+  private def percentStringLiteralSimple(delim: String): P[Expr] =
+    token((("%q".s / "%Q".s / "%".s) ~ percentBodySimple(delim)).map {
+      case _ ~ body => StringLiteral(body)
+    })
+
   private def percentWordArrayLiteral(open: String, close: String): P[Expr] =
     token((("%w".s / "%W".s) ~ percentBody(open, close)).map {
+      case _ ~ body =>
+        val words =
+          body
+            .split("\\s+")
+            .toList
+            .filter(_.nonEmpty)
+            .map(word => StringLiteral(word))
+        ArrayLiteral(words)
+    })
+
+  private def percentWordArrayLiteralSimple(delim: String): P[Expr] =
+    token((("%w".s / "%W".s) ~ percentBodySimple(delim)).map {
       case _ ~ body =>
         val words =
           body
@@ -339,23 +393,61 @@ object RubySubsetParser {
         ArrayLiteral(symbols)
     })
 
+  private def percentSymbolArrayLiteralSimple(delim: String): P[Expr] =
+    token((("%i".s / "%I".s) ~ percentBodySimple(delim)).map {
+      case _ ~ body =>
+        val symbols =
+          body
+            .split("\\s+")
+            .toList
+            .filter(_.nonEmpty)
+            .map(value => SymbolLiteral(value, UnknownSpan))
+        ArrayLiteral(symbols)
+    })
+
   private lazy val percentQuotedStringLiteral: P[Expr] =
     percentStringLiteral("{", "}") /
       percentStringLiteral("(", ")") /
       percentStringLiteral("[", "]") /
-      percentStringLiteral("<", ">")
+      percentStringLiteral("<", ">") /
+      percentStringLiteralSimple("\"") /
+      percentStringLiteralSimple("'") /
+      percentStringLiteralSimple("/")
+
+  private lazy val stringLikeLiteral: P[Expr] =
+    stringLiteral / singleQuotedStringLiteral / percentQuotedStringLiteral
+
+  private def concatStringExpr(lhs: Expr, rhs: Expr): Expr =
+    (lhs, rhs) match {
+      case (StringLiteral(left, _), StringLiteral(right, _)) =>
+        StringLiteral(left + right, UnknownSpan)
+      case _ =>
+        BinaryOp(lhs, "+", rhs)
+    }
+
+  private lazy val adjacentStringLiteral: P[Expr] =
+    (stringLikeLiteral ~ stringLikeLiteral.+).map {
+      case first ~ rest =>
+        rest.foldLeft(first)(concatStringExpr)
+    }
 
   private lazy val percentWordArray: P[Expr] =
     percentWordArrayLiteral("{", "}") /
       percentWordArrayLiteral("(", ")") /
       percentWordArrayLiteral("[", "]") /
-      percentWordArrayLiteral("<", ">")
+      percentWordArrayLiteral("<", ">") /
+      percentWordArrayLiteralSimple("\"") /
+      percentWordArrayLiteralSimple("'") /
+      percentWordArrayLiteralSimple("/")
 
   private lazy val percentSymbolArray: P[Expr] =
     percentSymbolArrayLiteral("{", "}") /
       percentSymbolArrayLiteral("(", ")") /
       percentSymbolArrayLiteral("[", "]") /
-      percentSymbolArrayLiteral("<", ">")
+      percentSymbolArrayLiteral("<", ">") /
+      percentSymbolArrayLiteralSimple("\"") /
+      percentSymbolArrayLiteralSimple("'") /
+      percentSymbolArrayLiteralSimple("/")
 
   private def percentRegexLiteral(open: String, close: String): P[Expr] =
     token(("%r".s ~ percentBody(open, close) ~ range('a' to 'z', 'A' to 'Z').*).map {
@@ -376,6 +468,25 @@ object RubySubsetParser {
       percentRegexLiteralSimple("'") /
       percentRegexLiteralSimple("/")
 
+  private def percentCommandLiteral(open: String, close: String): P[Expr] =
+    token(("%x".s ~ percentBody(open, close)).map {
+      case _ ~ body => StringLiteral(body)
+    })
+
+  private def percentCommandLiteralSimple(delim: String): P[Expr] =
+    token(("%x".s ~ percentBodySimple(delim)).map {
+      case _ ~ body => StringLiteral(body)
+    })
+
+  private lazy val percentCommand: P[Expr] =
+    percentCommandLiteral("{", "}") /
+      percentCommandLiteral("(", ")") /
+      percentCommandLiteral("[", "]") /
+      percentCommandLiteral("<", ">") /
+      percentCommandLiteralSimple("\"") /
+      percentCommandLiteralSimple("'") /
+      percentCommandLiteralSimple("/")
+
   private lazy val escapedRegexChar: P[String] =
     ("\\".s ~ any).map { case _ ~ c => s"\\$c" }
 
@@ -391,6 +502,8 @@ object RubySubsetParser {
   private lazy val symbolOperatorNameNoSpace: P[String] =
     "===".s /
       "<=>".s /
+      "=~".s /
+      "!~".s /
       "!=".s /
       "==".s /
       "<=".s /
@@ -401,6 +514,8 @@ object RubySubsetParser {
       "[]".s /
       "<".s /
       ">".s /
+      "+@".s /
+      "-@".s /
       "+".s /
       "-".s /
       "*".s /
@@ -409,18 +524,29 @@ object RubySubsetParser {
       "&".s /
       "|".s /
       "^".s /
-      "~".s
+      "~".s /
+      "`".s /
+      "!".s
+
+  private lazy val unicodeSymbolNameNoSpace: P[String] =
+    range('\u0080' to '\uffff').+.map(_.mkString)
 
   private lazy val symbolLiteral: P[Expr] =
-    (sym(":") ~ token("**".s / "*".s / "&".s)).map { case _ ~ name => SymbolLiteral(name, UnknownSpan) } /
-      (sym(":") ~ token(symbolOperatorNameNoSpace / methodIdentifierRaw)).map { case _ ~ name => SymbolLiteral(name, UnknownSpan) } /
-      (sym(":") ~ classVarName).map { case _ ~ name => SymbolLiteral(name, UnknownSpan) }
+    (symbolPrefix ~ token("**".s / "*".s / "&".s)).map { case _ ~ name => SymbolLiteral(name, UnknownSpan) } /
+      (symbolPrefix ~ token(symbolOperatorNameNoSpace / methodIdentifierRaw / reservedWord / unicodeSymbolNameNoSpace)).map {
+        case _ ~ name => SymbolLiteral(name, UnknownSpan)
+      } /
+      (symbolPrefix ~ constName).map { case _ ~ name => SymbolLiteral(name, UnknownSpan) } /
+      (symbolPrefix ~ classVarName).map { case _ ~ name => SymbolLiteral(name, UnknownSpan) }
       /
-      (sym(":") ~ instanceVarName).map { case _ ~ name => SymbolLiteral(name, UnknownSpan) }
+      (symbolPrefix ~ instanceVarName).map { case _ ~ name => SymbolLiteral(name, UnknownSpan) }
       /
-      (sym(":") ~ globalVarName).map { case _ ~ name => SymbolLiteral(name, UnknownSpan) }
+      (symbolPrefix ~ globalVarName).map { case _ ~ name => SymbolLiteral(name, UnknownSpan) }
       /
-      (sym(":") ~ token(("\"".s ~ (escapedChar / interpolationSegment / plainStringChar).* ~ "\"".s).map {
+      (symbolPrefix ~ token(("\"".s ~ (escapedChar / interpolationSegment / plainStringChar).* ~ "\"".s).map {
+        case _ ~ chars ~ _ => chars.mkString
+      })).map { case _ ~ name => SymbolLiteral(name, UnknownSpan) } /
+      (symbolPrefix ~ token(("'".s ~ (escapedSingleQuotedChar / plainSingleQuotedChar).* ~ "'".s).map {
         case _ ~ chars ~ _ => chars.mkString
       })).map { case _ ~ name => SymbolLiteral(name, UnknownSpan) }
 
@@ -452,14 +578,55 @@ object RubySubsetParser {
   private lazy val constRef: P[Expr] =
     constPathSegments.map(path => ConstRef(path))
 
+  private lazy val exprPostfixModifierSuffix: P[Expr => Expr] =
+    (kw("if") ~ refer(expr)).map {
+      case _ ~ condition =>
+        (target: Expr) => IfExpr(condition, List(ExprStmt(target)), Nil)
+    } /
+      (kw("unless") ~ refer(expr)).map {
+        case _ ~ condition =>
+          (target: Expr) => UnlessExpr(condition, List(ExprStmt(target)), Nil)
+      } /
+      (kw("rescue") ~ refer(expr)).map {
+        case _ ~ fallback =>
+          (target: Expr) =>
+            BeginRescue(
+              List(ExprStmt(target)),
+              List(RescueClause(Nil, None, List(ExprStmt(fallback)))),
+              Nil,
+              Nil
+            )
+      } /
+      (kw("while") ~ refer(expr)).map {
+        case _ ~ condition =>
+          (target: Expr) => WhileExpr(condition, List(ExprStmt(target)))
+      } /
+      (kw("until") ~ refer(expr)).map {
+        case _ ~ condition =>
+          (target: Expr) => UntilExpr(condition, List(ExprStmt(target)))
+      }
+
+  private lazy val exprWithPostfixModifier: P[Expr] =
+    (refer(expr) ~ (inlineSpacing ~> exprPostfixModifierSuffix).?).map {
+      case target ~ Some(modifier) => modifier(target)
+      case target ~ None => target
+    }
+
   private lazy val parenExpr: P[Expr] =
-    (sym("(") ~ refer(expr) ~ sym(")")).map { case _ ~ e ~ _ => e }
+    (sym("(") ~ exprWithPostfixModifier.? ~ sym(")")).map {
+      case _ ~ Some(e) ~ _ => e
+      case _ ~ None ~ _ => NilLiteral()
+    }
 
   private lazy val spacedExpr: P[Expr] =
     spacing ~> refer(expr) <~ spacing
 
+  private lazy val arrayElementExpr: P[Expr] =
+    (sym("*") ~ refer(expr)).map(_._2) /
+      refer(expr)
+
   private lazy val arrayLiteral: P[Expr] =
-    (sym("[") ~> spacing ~> sepBy0(spacedExpr, sym(",")) ~ ((sym(",") <~ spacing).?) <~ spacing <~ sym("]")).map {
+    (sym("[") ~> spacing ~> sepBy0(spacing ~> arrayElementExpr <~ spacing, sym(",")) ~ ((sym(",") <~ spacing).?) <~ spacing <~ sym("]")).map {
       case values ~ _ => ArrayLiteral(values)
     }
 
@@ -469,7 +636,8 @@ object RubySubsetParser {
     }
 
   private lazy val hashEntry: P[(Expr, Expr)] =
-    labelHashEntry /
+    (sym("**") ~ refer(expr)).map { case _ ~ value => SymbolLiteral("**", UnknownSpan) -> value } /
+      labelHashEntry /
       (refer(expr) ~ sym("=>") ~ refer(expr)).map { case key ~ _ ~ value => key -> value }
 
   private lazy val hashLiteral: P[Expr] =
@@ -478,12 +646,29 @@ object RubySubsetParser {
     }
 
   private lazy val callArgs: P[List[Expr]] =
-    (sym("(") ~> spacing ~> sepBy0(spacing ~> callArgExpr <~ spacing, sym(",")) ~ ((sym(",") <~ spacing).?) <~ spacing <~ sym(")")).map {
+    (sym("(") ~>
+      (
+        spacing ~>
+          sepBy0(spacing ~> callArgExpr <~ spacing, sym(",")) ~
+          ((sym(",") <~ spacing).?) <~
+          spacing <~
+          sym(")")
+      ).cut).map {
       case args ~ _ => args
     }
 
   private lazy val commandArgSep: P[Unit] =
     (inlineSpacing ~> sym(",") <~ spacing).void
+
+  private lazy val postfixModifierHeadKeyword: P[Any] =
+    kw("if") /
+      kw("unless") /
+      kw("while") /
+      kw("until") /
+      kw("rescue")
+
+  private lazy val commandArgHeadGuard: P[Unit] =
+    (!postfixModifierHeadKeyword).void
 
   private lazy val commandArgs: P[List[Expr]] =
     (callArgExpr ~ (commandArgSep ~> callArgExpr).* ~ (inlineSpacing ~> sym(",")).?).map {
@@ -491,8 +676,18 @@ object RubySubsetParser {
     }
 
   private lazy val blockPassArgExpr: P[Expr] =
-    (sym("&") ~ identifier).map { case _ ~ name => LocalVar(s"&$name") } /
-      (sym("&") ~ symbolLiteral).map { case _ ~ symbol => symbol }
+    (
+      sym("&") ~
+      (identifier <~
+        !sym("(").and <~
+        !sym("[").and <~
+        !sym(".").and <~
+        !sym("&.").and <~
+        !sym("::").and <~
+        !(inlineSpacing ~> (sym("{") / kw("do"))).and)
+    ).map { case _ ~ name => LocalVar(s"&$name") } /
+      (sym("&") ~ symbolLiteral).map { case _ ~ symbol => symbol } /
+      (sym("&") ~ refer(expr)).map(_._2)
 
   private lazy val doubleSplatArgExpr: P[Expr] =
     (sym("**") ~ refer(expr)).map(_._2)
@@ -507,18 +702,26 @@ object RubySubsetParser {
     }
 
   private lazy val hashRocketArgKeyExpr: P[Expr] =
-    symbolLiteral / stringLiteral / variable / constRef
+    symbolLiteral / stringLiteral / variable / constRef / integerLiteral / floatLiteral / parenExpr
 
   private lazy val hashRocketArgExpr: P[Expr] =
     (((hashRocketArgKeyExpr <~ sym("=>").and).and ~> hashRocketArgKeyExpr) ~ sym("=>") ~ refer(expr)).map {
       case key ~ _ ~ value => HashLiteral(List(key -> value))
     }
 
+  private lazy val forwardingArgExpr: P[Expr] =
+    sym("...").map(_ => LocalVar("..."))
+
   private lazy val callArgExpr: P[Expr] =
+    forwardingArgExpr / blockPassArgExpr / doubleSplatArgExpr / splatArgExpr / keywordArgExpr / hashRocketArgExpr / refer(expr)
+
+  private lazy val bracketArgExpr: P[Expr] =
     blockPassArgExpr / doubleSplatArgExpr / splatArgExpr / keywordArgExpr / hashRocketArgExpr / refer(expr)
 
+  // NOTE: keep this tight (`foo(` only). If whitespace is allowed here, command-style
+  // forms like `assert_equal (+x), y` are misread as `assert_equal(+x)`.
   private lazy val functionCall: P[Expr] =
-    (methodIdentifier ~ callArgs).map { case name ~ args => Call(None, name, args) }
+    (methodIdentifierNoSpace ~ callArgs).map { case name ~ args => Call(None, name, args) }
 
   private lazy val receiverForCommand: P[Expr] =
     constRef / selfExpr / variable
@@ -527,12 +730,12 @@ object RubySubsetParser {
     (receiverForCommand <~ sym(".")) ~ receiverMethodNameNoSpace
 
   private lazy val commandCall: P[Expr] =
-    ((((methodIdentifierNoSpace <~ spacing1) ~ commandArgs.and).and ~> (methodIdentifierNoSpace <~ spacing1)) ~ commandArgs).map {
+    (((methodIdentifierNoSpace <~ spacing1) ~ (commandArgHeadGuard ~> commandArgs))).map {
       case name ~ args => Call(None, name, args)
     }
 
   private lazy val receiverCommandCall: P[Expr] =
-    ((((receiverCommandHead <~ spacing1) ~ commandArgs.and).and ~> (receiverCommandHead <~ spacing1)) ~ commandArgs).map {
+    (((receiverCommandHead <~ spacing1) ~ (commandArgHeadGuard ~> commandArgs))).map {
       case receiverAndMethod ~ args =>
         val receiver ~ methodName = receiverAndMethod
         Call(Some(receiver), methodName, args)
@@ -553,17 +756,28 @@ object RubySubsetParser {
     }
 
   private lazy val chainedCommandCall: P[Expr] =
-    ((((chainedCallExpr <~ spacing1) ~ commandArgs.and).and ~> (chainedCallExpr <~ spacing1)) ~ commandArgs).map {
+    (((chainedCallExpr <~ spacing1) ~ (commandArgHeadGuard ~> commandArgs))).map {
       case call ~ args => appendCommandArgs(call, args)
     }
 
   private lazy val primaryNoCall: P[Expr] =
     lambdaLiteral /
+      singletonClassExpr /
+      refer(beginStmt).map(_.asInstanceOf[Expr]) /
+      refer(ifStmt).map(_.asInstanceOf[Expr]) /
+      refer(unlessStmt).map(_.asInstanceOf[Expr]) /
+      refer(caseStmt).map(_.asInstanceOf[Expr]) /
+      // NOTE: whileStmt/untilStmt NOT here — their `do` conflicts with blockAttachSuffix.cut
       integerLiteral /
       floatLiteral /
+      token(("?".s ~ !horizontalSpaceChar.and ~ !newlineChar.and ~ (escapedChar / any)).map {
+        case _ ~ _ ~ _ ~ char => StringLiteral(char)
+      }) /
+      adjacentStringLiteral /
       stringLiteral /
       singleQuotedStringLiteral /
       backtickLiteral /
+      percentCommand /
       percentQuotedStringLiteral /
       percentWordArray /
       percentSymbolArray /
@@ -579,10 +793,13 @@ object RubySubsetParser {
       parenExpr
 
   private lazy val commandExpr: P[Expr] =
-    receiverCommandCall / commandCall
+    (receiverCommandCall / commandCall).memo
 
   private lazy val bareNoArgPunctuatedCall: P[Expr] =
     punctuatedMethodIdentifier.map(name => Call(None, name, Nil))
+
+  private lazy val bareNoArgKeywordCall: P[Expr] =
+    token(bareKeywordMethodNameNoSpace).map(name => Call(None, name, Nil))
 
   private lazy val positionalParam: P[String] =
     (identifier ~ (sym("=") ~ refer(expr)).?).map(_._1)
@@ -593,9 +810,19 @@ object RubySubsetParser {
     }
 
   private lazy val formalParam: P[String] =
-    (sym("**") ~ identifier).map { case _ ~ name => s"**$name" } /
+    sym("...").map(_ => "...") /
+    (sym("(") ~> sepBy0(refer(formalParam), sym(",")) <~ sym(")")).map { parts =>
+      s"(${parts.mkString(",")})"
+    } /
+      (sym("**") ~ identifier).map { case _ ~ name => s"**$name" } /
+      (sym("**") ~ kw("nil")).map(_ => "**nil") /
+      sym("**").map(_ => "**") /
       (sym("*") ~ identifier).map { case _ ~ name => s"*$name" } /
+      (sym("*") ~ kw("nil")).map(_ => "*nil") /
+      sym("*").map(_ => "*") /
       (sym("&") ~ identifier).map { case _ ~ name => s"&$name" } /
+      (sym("&") ~ kw("nil")).map(_ => "&nil") /
+      sym("&").map(_ => "&") /
       keywordParam /
       positionalParam
 
@@ -612,17 +839,25 @@ object RubySubsetParser {
       kw("do") ~
       blockParams.? ~
       statementSep.* ~
-      blockStatementsUntil(kw("ensure") / kw("end")) ~
+      blockStatementsUntil(kw("rescue") / kw("else") / kw("ensure") / kw("end")) ~
+      statementSep.* ~
+      refer(rescueClause).* ~
+      statementSep.* ~
+      (kw("else") ~ statementSep.* ~ blockStatementsUntil(kw("ensure") / kw("end"))).? ~
       statementSep.* ~
       (kw("ensure") ~ statementSep.* ~ blockStatementsUntil(kw("end"))).? ~
       statementSep.* ~
       kw("end")
     ).map {
-      case _ ~ maybeParams ~ _ ~ body ~ _ ~ ensureOpt ~ _ ~ _ =>
-        val statements = ensureOpt match {
-          case Some(_ ~ _ ~ ensureBody) => List(BeginRescue(body, Nil, Nil, ensureBody))
-          case None => body
-        }
+      case _ ~ maybeParams ~ _ ~ body ~ _ ~ rescues ~ _ ~ elseOpt ~ _ ~ ensureOpt ~ _ ~ _ =>
+        val elseBody = elseOpt.map { case _ ~ _ ~ statements => statements }.getOrElse(Nil)
+        val ensureBody = ensureOpt.map { case _ ~ _ ~ statements => statements }.getOrElse(Nil)
+        val statements =
+          if(rescues.nonEmpty || elseBody.nonEmpty || ensureBody.nonEmpty) {
+            List(BeginRescue(body, rescues, elseBody, ensureBody))
+          } else {
+            body
+          }
         Block(maybeParams.getOrElse(Nil), statements)
     }
 
@@ -642,7 +877,7 @@ object RubySubsetParser {
     }
 
   private lazy val lineBreak: P[Unit] =
-    ("\n".s ~ inlineSpacing).void
+    (inlineSpacing ~> "\n".s ~ inlineSpacing).void
 
   private lazy val statementSep: P[Unit] =
     sym(";").void / lineBreak.+.void
@@ -677,23 +912,39 @@ object RubySubsetParser {
     receiverMethodNameNoSpace / operatorMethodName
 
   private lazy val methodSuffix: P[Expr => Expr] =
-    ((sym(".") / sym("&.")) ~ suffixMethodName ~ callArgs.?).map {
+    ((sym(".") / sym("&.") / sym("::") / (lineBreak ~> sym(".")) / (lineBreak ~> sym("&.")) / (lineBreak ~> sym("::"))) ~ suffixMethodName ~ callArgs.?).map {
       case _ ~ name ~ argsOpt =>
         val args = argsOpt.getOrElse(Nil)
         (receiver: Expr) => Call(Some(receiver), name, args)
     }
 
+  private lazy val bracketCallArgs: P[List[Expr]] =
+    (sym("[") ~>
+      (
+        spacing ~>
+          sepBy0(spacing ~> bracketArgExpr <~ spacing, sym(",")) ~
+          ((sym(",") <~ spacing).?) <~
+          spacing <~
+          sym("]")
+      ).cut).map {
+      case args ~ _ => args
+    }
+
   private lazy val indexSuffix: P[Expr => Expr] =
-    (sym("[") ~ spacing ~ sepBy0(spacedExpr, sym(",")) ~ spacing ~ sym("]")).map {
-      case _ ~ _ ~ args ~ _ ~ _ =>
-        (receiver: Expr) => Call(Some(receiver), "[]", args)
+    bracketCallArgs.map { args =>
+      (receiver: Expr) => Call(Some(receiver), "[]", args)
     }
 
   private lazy val callSuffix: P[Expr => Expr] =
     methodSuffix / indexSuffix / blockAttachSuffix
 
   private lazy val blockAttachSuffix: P[Expr => Expr] =
-    (inlineSpacing ~> refer(blockLiteral)).map { block =>
+    ((inlineSpacing ~> (kw("do").and / sym("{").and)) ~> refer(blockLiteral).cut).map { block =>
+      (receiver: Expr) => CallWithBlock(receiver, block)
+    }
+
+  private lazy val braceBlockAttachSuffix: P[Expr => Expr] =
+    ((inlineSpacing ~> sym("{").and) ~> braceBlock.cut).map { block =>
       (receiver: Expr) => CallWithBlock(receiver, block)
     }
 
@@ -701,24 +952,24 @@ object RubySubsetParser {
     methodSuffix / blockAttachSuffix
 
   private lazy val postfixNoIndexExpr: P[Expr] =
-    ((functionCall / commandExpr / bareNoArgPunctuatedCall / primaryNoCall) ~ nonIndexCallSuffix.*).map {
+    ((functionCall / commandExpr / bareNoArgPunctuatedCall / bareNoArgKeywordCall / primaryNoCall) ~ nonIndexCallSuffix.*).map {
       case base ~ suffixes => suffixes.foldLeft(base)((current, suffix) => suffix(current))
-    }
+    }.memo
 
   private lazy val indexTarget: P[(Expr, List[Expr])] =
-    (postfixNoIndexExpr ~ sym("[") ~ spacing ~ sepBy0(spacedExpr, sym(",")) ~ spacing ~ sym("]")).map {
-      case receiver ~ _ ~ _ ~ args ~ _ ~ _ => receiver -> args
+    (postfixNoIndexExpr ~ bracketCallArgs).map {
+      case receiver ~ args => receiver -> args
     }
 
   private lazy val postfixExpr: P[Expr] =
-    ((functionCall / commandExpr / bareNoArgPunctuatedCall / primaryNoCall) ~ callSuffix.*).map {
+    ((functionCall / commandExpr / bareNoArgPunctuatedCall / bareNoArgKeywordCall / primaryNoCall) ~ callSuffix.*).map {
       case base ~ suffixes => suffixes.foldLeft(base)((current, suffix) => suffix(current))
-    }
+    }.memo
 
   private lazy val chainedCallExpr: P[Expr] =
-    ((functionCall / commandExpr / bareNoArgPunctuatedCall / primaryNoCall) ~ callSuffix.+).map {
+    ((functionCall / commandExpr / bareNoArgPunctuatedCall / bareNoArgKeywordCall / primaryNoCall) ~ callSuffix.+).map {
       case base ~ suffixes => suffixes.foldLeft(base)((current, suffix) => suffix(current))
-    }
+    }.memo
 
   private def infix(op: String): P[(Expr, Expr) => Expr] =
     sym(op).map(_ => (lhs: Expr, rhs: Expr) => BinaryOp(lhs, op, rhs))
@@ -728,6 +979,9 @@ object RubySubsetParser {
 
   private def infixLogicalKeyword(op: String): P[(Expr, Expr) => Expr] =
     ((op.s <~ !identCont) <~ spacing).map(_ => (lhs: Expr, rhs: Expr) => BinaryOp(lhs, op, rhs))
+
+  private def infixLogicalSymbol(op: String): P[(Expr, Expr) => Expr] =
+    ((string(op) <~ !"=".s) <~ spacing).map(_ => (lhs: Expr, rhs: Expr) => BinaryOp(lhs, op, rhs))
 
   private lazy val powerExpr: P[Expr] =
     (postfixExpr ~ (sym("**") ~> refer(powerExpr)).?).map {
@@ -744,6 +998,9 @@ object RubySubsetParser {
     } /
       (sym("~") ~ refer(unaryExpr)).map {
         case _ ~ target => UnaryOp("~", target)
+      } /
+      (sym("*") ~ refer(unaryExpr)).map {
+        case _ ~ target => UnaryOp("*", target)
       } /
       (sym("-") ~ refer(unaryExpr)).map {
         case _ ~ target => UnaryOp("-", target)
@@ -772,22 +1029,31 @@ object RubySubsetParser {
     chainl(bitOrExpr)(infix("<=") / infix(">=") / infix("<") / infix(">"))
 
   private lazy val equalityExpr: P[Expr] =
-    chainl(relationalExpr)(infix("==") / infix("===") / infix("!=") / infix("<=>") / infix("=~") / infix("!~"))
+    chainl(relationalExpr)(infix("===") / infix("<=>") / infix("==") / infix("!=") / infix("=~") / infix("!~"))
+
+  private lazy val rangeOp: P[String] =
+    sym("...") / sym("..")
 
   private lazy val rangeExpr: P[Expr] =
-    (equalityExpr ~ ((sym("..") / sym("...")) ~ equalityExpr).?).map {
-      case start ~ Some(op ~ end) => RangeExpr(start, end, exclusive = op == "...")
-      case start ~ None => start
-    }
+    (equalityExpr ~ (rangeOp ~ equalityExpr.?).?).map {
+      case start ~ Some(op ~ endOpt) =>
+        RangeExpr(start, endOpt.getOrElse(NilLiteral()), exclusive = op == "...")
+      case start ~ None =>
+        start
+    } /
+      (rangeOp ~ equalityExpr).map {
+        case op ~ end =>
+          RangeExpr(NilLiteral(), end, exclusive = op == "...")
+      }
 
   private lazy val andExpr: P[Expr] =
-    chainl(rangeExpr)(infix("&&") / infixLogicalKeyword("and"))
+    chainl(rangeExpr)(infixLogicalSymbol("&&") / infixLogicalKeyword("and"))
 
   private lazy val orExpr: P[Expr] =
-    chainl(andExpr)(infix("||") / infixLogicalKeyword("or"))
+    chainl(andExpr)(infixLogicalSymbol("||") / infixLogicalKeyword("or"))
 
   private lazy val conditionalExpr: P[Expr] =
-    (orExpr ~ (sym("?") ~ refer(expr) ~ sym(":") ~ refer(expr)).?).map {
+    (orExpr ~ ((spacing ~> sym("?")) ~ (refer(expr) <~ (spacing ~> ":".s).and) ~ (spacing ~> sym(":")) ~ refer(expr)).?).map {
       case condition ~ Some(_ ~ thenExpr ~ _ ~ elseExpr) =>
         IfExpr(
           condition,
@@ -798,46 +1064,157 @@ object RubySubsetParser {
         condition
     }
 
+  // ===== NoBlock expression hierarchy for loop/for conditions =====
+  // Prevents blockAttachSuffix from stealing "do" keyword in while/until/for conditions.
+  private lazy val callSuffixNoBlock: P[Expr => Expr] = methodSuffix / indexSuffix / braceBlockAttachSuffix
+
+  private lazy val postfixExprNoBlock: P[Expr] =
+    ((functionCall / commandExpr / bareNoArgPunctuatedCall / bareNoArgKeywordCall / primaryNoCall) ~ callSuffixNoBlock.*).map {
+      case base ~ suffixes => suffixes.foldLeft(base)((current, suffix) => suffix(current))
+    }.memo
+
+  private lazy val powerExprNoBlock: P[Expr] =
+    (postfixExprNoBlock ~ (sym("**") ~> refer(powerExprNoBlock)).?).map {
+      case base ~ Some(exp) => BinaryOp(base, "**", exp)
+      case base ~ None => base
+    }
+
+  private lazy val unaryExprNoBlock: P[Expr] =
+    (kw("not") ~ refer(unaryExprNoBlock)).map {
+      case _ ~ target => UnaryOp("not", target)
+    } /
+    (sym("!") ~ refer(unaryExprNoBlock)).map {
+      case _ ~ target => UnaryOp("!", target)
+    } /
+    (sym("~") ~ refer(unaryExprNoBlock)).map {
+      case _ ~ target => UnaryOp("~", target)
+    } /
+    (sym("*") ~ refer(unaryExprNoBlock)).map {
+      case _ ~ target => UnaryOp("*", target)
+    } /
+    (sym("-") ~ refer(unaryExprNoBlock)).map {
+      case _ ~ target => UnaryOp("-", target)
+    } /
+    (sym("+") ~ refer(unaryExprNoBlock)).map {
+      case _ ~ target => UnaryOp("+", target)
+    } /
+    (powerExprNoBlock <~ horizontalSpacing)
+
+  private lazy val mulDivExprNoBlock: P[Expr] =
+    chainl(unaryExprNoBlock)(infix("*") / infix("/") / infix("%"))
+
+  private lazy val addSubExprNoBlock: P[Expr] =
+    chainl(mulDivExprNoBlock)(infix("+") / infix("-"))
+
+  private lazy val shiftExprNoBlock: P[Expr] =
+    chainl(addSubExprNoBlock)(infix("<<") / infix(">>"))
+
+  private lazy val bitAndExprNoBlock: P[Expr] =
+    chainl(shiftExprNoBlock)(infix("&"))
+
+  private lazy val bitOrExprNoBlock: P[Expr] =
+    chainl(bitAndExprNoBlock)(infix("|") / infix("^"))
+
+  private lazy val relationalExprNoBlock: P[Expr] =
+    chainl(bitOrExprNoBlock)(infix("<=") / infix(">=") / infix("<") / infix(">"))
+
+  private lazy val equalityExprNoBlock: P[Expr] =
+    chainl(relationalExprNoBlock)(infix("===") / infix("<=>") / infix("==") / infix("!=") / infix("=~") / infix("!~"))
+
+  private lazy val rangeExprNoBlock: P[Expr] =
+    (equalityExprNoBlock ~ (rangeOp ~ equalityExprNoBlock.?).?).map {
+      case start ~ Some(op ~ endOpt) =>
+        RangeExpr(start, endOpt.getOrElse(NilLiteral()), exclusive = op == "...")
+      case start ~ None =>
+        start
+    } /
+    (rangeOp ~ equalityExprNoBlock).map {
+      case op ~ end =>
+        RangeExpr(NilLiteral(), end, exclusive = op == "...")
+    }
+
+  private lazy val andExprNoBlock: P[Expr] =
+    chainl(rangeExprNoBlock)(infixLogicalSymbol("&&") / infixLogicalKeyword("and"))
+
+  private lazy val orExprNoBlock: P[Expr] =
+    chainl(andExprNoBlock)(infixLogicalSymbol("||") / infixLogicalKeyword("or"))
+
+  // conditionExpr: used as the condition of while/until/for — excludes do-blocks
+  private lazy val conditionAssignExpr: P[Expr] =
+    (((assignableName <~ sym("=").and).and ~> assignableName) ~ sym("=") ~ spacing ~ refer(conditionExpr)).map {
+      case name ~ _ ~ _ ~ value => AssignExpr(name, value)
+    }
+
+  private lazy val conditionExpr: P[Expr] =
+    (conditionAssignExpr /
+      (orExprNoBlock ~ ((spacing ~> sym("?")) ~ (refer(conditionExpr) <~ (spacing ~> ":".s).and) ~ (spacing ~> sym(":")) ~ refer(conditionExpr)).?).map {
+      case condition ~ Some(_ ~ thenExpr ~ _ ~ elseExpr) =>
+        IfExpr(condition, List(ExprStmt(thenExpr)), List(ExprStmt(elseExpr)))
+      case condition ~ None =>
+        condition
+    }).memo
+
+  private lazy val chainedAssignRhsExpr: P[Expr] =
+    (((assignableName <~ sym("=").and).and ~> assignableName) ~ sym("=") ~ spacing ~ refer(chainedAssignRhsExpr)).map {
+      case name ~ _ ~ _ ~ value => AssignExpr(name, value)
+    } /
+      conditionalExpr
+
+  private lazy val assignValueExpr: P[Expr] =
+    sepBy1(splatArgExpr / chainedAssignRhsExpr, sym(",")).map {
+      case value :: Nil => value
+      case values => ArrayLiteral(values)
+    }
+
   private lazy val assignExpr: P[Expr] =
-    (((assignableName <~ sym("=").and).and ~> assignableName) ~ sym("=") ~ refer(expr)).map {
-      case name ~ _ ~ value => AssignExpr(name, value)
+    (((assignableName <~ sym("=").and).and ~> assignableName) ~ sym("=") ~ spacing ~ assignValueExpr).map {
+      case name ~ _ ~ _ ~ value => AssignExpr(name, value)
     }
 
   private lazy val receiverAssignableHead: P[Expr ~ String] =
-    (receiverForCommand <~ sym(".")) ~ identifier
+    (receiverForCommand <~ (sym(".") / sym("&."))) ~ identifier
 
   private lazy val receiverAssignExpr: P[Expr] =
-    (((receiverAssignableHead <~ sym("=").and).and ~> receiverAssignableHead) ~ sym("=") ~ refer(expr)).map {
-      case receiver ~ name ~ _ ~ value =>
+    (((receiverAssignableHead <~ sym("=").and).and ~> receiverAssignableHead) ~ sym("=") ~ spacing ~ assignValueExpr).map {
+      case receiver ~ name ~ _ ~ _ ~ value =>
         Call(Some(receiver), s"${name}=", List(value))
     }
 
   private lazy val receiverLogicalAssignExpr: P[Expr] =
-    (((receiverAssignableHead <~ (sym("||=") / sym("&&=")).and).and ~> receiverAssignableHead) ~ (sym("||=") / sym("&&=")) ~ refer(expr)).map {
-      case receiver ~ name ~ op ~ value =>
+    (((receiverAssignableHead <~ (sym("||=") / sym("&&=")).and).and ~> receiverAssignableHead) ~ (sym("||=") / sym("&&=")) ~ spacing ~ refer(expr)).map {
+      case receiver ~ name ~ op ~ _ ~ value =>
         val lhs = Call(Some(receiver), name, Nil)
         val underlying = if(op == "||=") "||" else "&&"
         BinaryOp(lhs, underlying, value)
     }
 
   private lazy val indexAssignExpr: P[Expr] =
-    (((indexTarget <~ sym("=").and).and ~> indexTarget) ~ sym("=") ~ refer(expr)).map {
-      case (receiver, args) ~ _ ~ value =>
+    (((indexTarget <~ sym("=").and).and ~> indexTarget) ~ sym("=") ~ spacing ~ assignValueExpr).map {
+      case (receiver, args) ~ _ ~ _ ~ value =>
         Call(Some(receiver), "[]=", args :+ value)
     }
 
   private lazy val indexLogicalAssignExpr: P[Expr] =
-    (((indexTarget <~ (sym("||=") / sym("&&=")).and).and ~> indexTarget) ~ (sym("||=") / sym("&&=")) ~ refer(expr)).map {
-      case (receiver, args) ~ op ~ value =>
+    (((indexTarget <~ (sym("||=") / sym("&&=")).and).and ~> indexTarget) ~ (sym("||=") / sym("&&=")) ~ spacing ~ refer(expr)).map {
+      case (receiver, args) ~ op ~ _ ~ value =>
         val lhs = Call(Some(receiver), "[]", args)
         val underlying = if(op == "||=") "||" else "&&"
         val rhs = BinaryOp(lhs, underlying, value)
         Call(Some(receiver), "[]=", args :+ rhs)
     }
 
+  private lazy val indexCompoundAssignExpr: P[Expr] =
+    (((indexTarget <~ compoundAssignOperator.and).and ~> indexTarget) ~ compoundAssignOperator ~ spacing ~ refer(expr)).map {
+      case (receiver, args) ~ op ~ _ ~ value =>
+        val underlying = op.dropRight(1)
+        val lhs = Call(Some(receiver), "[]", args)
+        val rhs = BinaryOp(lhs, underlying, value)
+        Call(Some(receiver), "[]=", args :+ rhs)
+    }
+
   private lazy val receiverCompoundAssignExpr: P[Expr] =
-    (((receiverAssignableHead <~ compoundAssignOperator.and).and ~> receiverAssignableHead) ~ compoundAssignOperator ~ refer(expr)).map {
-      case receiver ~ name ~ op ~ value =>
+    (((receiverAssignableHead <~ compoundAssignOperator.and).and ~> receiverAssignableHead) ~ compoundAssignOperator ~ spacing ~ refer(expr)).map {
+      case receiver ~ name ~ op ~ _ ~ value =>
         val underlying = op.dropRight(1)
         val lhs = Call(Some(receiver), name, Nil)
         val rhs = BinaryOp(lhs, underlying, value)
@@ -845,29 +1222,30 @@ object RubySubsetParser {
     }
 
   private lazy val logicalAssignExpr: P[Expr] =
-    (((assignableName <~ (sym("||=") / sym("&&=")).and).and ~> assignableName) ~ (sym("||=") / sym("&&=")) ~ refer(expr)).map {
-      case name ~ op ~ value =>
+    (((assignableName <~ (sym("||=") / sym("&&=")).and).and ~> assignableName) ~ (sym("||=") / sym("&&=")) ~ spacing ~ refer(expr)).map {
+      case name ~ op ~ _ ~ value =>
         val underlying = if(op == "||=") "||" else "&&"
         AssignExpr(name, BinaryOp(assignableAsExpr(name), underlying, value))
     }
 
   private lazy val compoundAssignExpr: P[Expr] =
-    (((assignableName <~ compoundAssignOperator.and).and ~> assignableName) ~ compoundAssignOperator ~ refer(expr)).map {
-      case name ~ op ~ value =>
+    (((assignableName <~ compoundAssignOperator.and).and ~> assignableName) ~ compoundAssignOperator ~ spacing ~ refer(expr)).map {
+      case name ~ op ~ _ ~ value =>
         val underlying = op.dropRight(1)
         AssignExpr(name, BinaryOp(assignableAsExpr(name), underlying, value))
     }
 
   private lazy val expr: P[Expr] =
-    receiverAssignExpr /
+    (receiverAssignExpr /
       receiverLogicalAssignExpr /
       receiverCompoundAssignExpr /
       indexLogicalAssignExpr /
+      indexCompoundAssignExpr /
       indexAssignExpr /
       logicalAssignExpr /
       compoundAssignExpr /
       assignExpr /
-      conditionalExpr
+      conditionalExpr).memo
 
   private lazy val assignableName: P[String] =
     identifier / instanceVarName / classVarName / globalVarName
@@ -891,28 +1269,64 @@ object RubySubsetParser {
       sym("^=")
 
   private lazy val compoundAssignStmt: P[Statement] =
-    (assignableName ~ compoundAssignOperator ~ refer(expr)).map {
-      case name ~ op ~ value =>
+    (assignableName ~ compoundAssignOperator ~ spacing ~ refer(expr)).map {
+      case name ~ op ~ _ ~ value =>
         val underlying = op.dropRight(1)
         Assign(name, BinaryOp(assignableAsExpr(name), underlying, value))
     }
 
   private lazy val logicalAssignStmt: P[Statement] =
-    (assignableName ~ (sym("||=") / sym("&&=")) ~ refer(expr)).map {
-      case name ~ op ~ value =>
+    (assignableName ~ (sym("||=") / sym("&&=")) ~ spacing ~ refer(expr)).map {
+      case name ~ op ~ _ ~ value =>
         val underlying = if(op == "||=") "||" else "&&"
         Assign(name, BinaryOp(assignableAsExpr(name), underlying, value))
     }
 
   private lazy val assignStmt: P[Statement] =
-    (assignableName ~ sym("=") ~ refer(expr)).map {
-      case name ~ _ ~ value => Assign(name, value)
+    (assignableName ~ sym("=") ~ spacing ~ assignValueExpr).map {
+      case name ~ _ ~ _ ~ value => Assign(name, value)
     }
 
+  private lazy val multiAssignTargetExpr: P[Expr] =
+    indexTarget.map { case (receiver, args) => Call(Some(receiver), "[]", args) } /
+      receiverAssignableHead.map { case receiver ~ name => Call(Some(receiver), name, Nil) } /
+      assignableName.map(assignableAsExpr)
+
+  private def multiAssignTargetName(target: Expr): String =
+    target match {
+      case LocalVar(name, _) => name
+      case InstanceVar(name, _) => name
+      case ClassVar(name, _) => name
+      case GlobalVar(name, _) => name
+      case SelfExpr(_) => "self"
+      case ConstRef(path, _) => path.mkString("::")
+      case Call(Some(receiver), "[]", _, _) => s"${multiAssignTargetName(receiver)}[]"
+      case Call(Some(receiver), name, Nil, _) => s"${multiAssignTargetName(receiver)}.$name"
+      case other => other.toString
+    }
+
+  private lazy val multiAssignElement: P[String] =
+    (sym("*") ~ multiAssignTargetExpr.?).map {
+      case _ ~ Some(target) => s"*${multiAssignTargetName(target)}"
+      case _ ~ None => "*"
+    } /
+      multiAssignTargetExpr.map(multiAssignTargetName)
+
+  private lazy val multiAssignNames: P[List[String]] =
+    (multiAssignElement ~ (sym(",") ~ multiAssignElement).+ ~ sym(",").?).map {
+      case first ~ rest ~ _ => first :: rest.map(_._2)
+    } /
+      (multiAssignElement ~ (sym(",") ~ multiAssignElement).* ~ sym(",")).map {
+        case first ~ rest ~ _ => first :: rest.map(_._2)
+      } /
+      (sym("*") ~ multiAssignTargetExpr.?).map {
+        case _ ~ Some(target) => List(s"*${multiAssignTargetName(target)}")
+        case _ ~ None => List("*")
+      }
+
   private lazy val multiAssignStmt: P[Statement] =
-    (assignableName ~ (sym(",") ~ assignableName).+ ~ sym("=") ~ refer(expr)).map {
-      case first ~ rest ~ _ ~ value =>
-        val names = first :: rest.map(_._2)
+    (multiAssignNames ~ sym("=") ~ spacing ~ assignValueExpr).map {
+      case names ~ _ ~ _ ~ value =>
         MultiAssign(names, value)
     }
 
@@ -920,8 +1334,21 @@ object RubySubsetParser {
     constPathSegments.map(_.mkString("::"))
 
   private lazy val constAssignStmt: P[Statement] =
-    (((constAssignName <~ sym("=").and).and ~> constAssignName) ~ sym("=") ~ refer(expr)).map {
-      case name ~ _ ~ value => Assign(name, value)
+    (((constAssignName <~ sym("=").and).and ~> constAssignName) ~ sym("=") ~ spacing ~ assignValueExpr).map {
+      case name ~ _ ~ _ ~ value => Assign(name, value)
+    }
+
+  private lazy val defExpr: P[Expr] =
+    refer(defStmt).map {
+      case Def(name, _, _, _) =>
+        SymbolLiteral(name.split('.').lastOption.getOrElse(name), UnknownSpan)
+      case _ =>
+        NilLiteral()
+    }
+
+  private lazy val assignDefStmt: P[Statement] =
+    (((assignableName <~ sym("=").and).and ~> assignableName) ~ sym("=") ~ spacing ~ defExpr).map {
+      case name ~ _ ~ _ ~ value => Assign(name, value)
     }
 
   private lazy val returnValueExpr: P[Expr] =
@@ -930,8 +1357,11 @@ object RubySubsetParser {
       case values => ArrayLiteral(values)
     }
 
+  private lazy val returnValueHeadGuard: P[Unit] =
+    (!postfixModifierHeadKeyword).void
+
   private lazy val returnStmt: P[Statement] =
-    (kw("return") ~ returnValueExpr.?).map {
+    (kw("return") ~ ((returnValueHeadGuard ~> returnValueExpr).?)).map {
       case _ ~ value => Return(value)
     }
 
@@ -947,13 +1377,27 @@ object RubySubsetParser {
   private lazy val defReceiverName: P[String] =
     constPathSegments.map(_.mkString("::")) /
       kw("self").map(_ => "self") /
+      instanceVarName /
+      classVarName /
+      globalVarName /
       identifierNoSpace
 
+  private lazy val defMethodName: P[String] =
+    token(
+      ("`".s ~ (escapedAnyChar / (!"`".s ~ any).map(_._2)).* ~ "`".s).map {
+        case _ ~ chars ~ _ => s"`${chars.mkString}`"
+      } /
+        methodIdentifierNoSpace /
+        bareKeywordMethodNameNoSpace /
+        receiverKeywordMethodNameNoSpace /
+        symbolOperatorNameNoSpace
+    )
+
   private lazy val defName: P[String] =
-    ((defReceiverName <~ sym(".")) ~ methodIdentifier).map {
+    ((defReceiverName <~ sym(".")) ~ defMethodName).map {
       case receiver ~ methodName => s"$receiver.$methodName"
     } /
-      methodIdentifier
+      defMethodName
 
   private lazy val simpleStatement: P[Statement] =
     returnStmt /
@@ -962,6 +1406,7 @@ object RubySubsetParser {
       compoundAssignStmt /
       constAssignStmt /
       multiAssignStmt /
+      assignDefStmt /
       assignStmt /
       chainedCommandCall.map(ExprStmt(_)) /
       refer(expr).map(ExprStmt(_))
@@ -973,6 +1418,7 @@ object RubySubsetParser {
       refer(untilStmt) /
       refer(forStmt) /
       refer(caseStmt) /
+      ((kw("private") / kw("public") / kw("protected")) ~> refer(defStmt)) /
       refer(defStmt) /
       refer(singletonClassStmt) /
       refer(classStmt) /
@@ -983,20 +1429,26 @@ object RubySubsetParser {
     )
 
   private lazy val statement: P[Statement] =
-    (statementBase ~ (inlineSpacing ~> modifierSuffix).?).map {
-      case stmt ~ Some(modifier) => modifier(stmt)
-      case stmt ~ None => stmt
+    guarded("statement") {
+      (statementBase ~ (inlineSpacing ~> modifierSuffix).?).map {
+        case stmt ~ Some(modifier) => modifier(stmt)
+        case stmt ~ None => stmt
+      }
     }
 
   private lazy val topLevelStatements: P[List[Statement]] =
     sepBy0(refer(statement), statementSep)
 
   private def blockStatementsUntil(stop: P[Any]): P[List[Statement]] =
-    (stop.and ~> success(Nil)) /
-      ((refer(statement) ~ (statementSep.+ ~> refer(blockStatementsUntil(stop))).?).map {
-        case stmt ~ Some(rest) => stmt :: rest
-        case stmt ~ None => List(stmt)
-      })
+    guarded("blockStatementsUntil") {
+      (stop.and ~> success(Nil)) /
+        ((refer(statement) ~ (
+          (statementSep.+ ~> refer(blockStatementsUntil(stop))) /
+            (stop.and ~> success(Nil))
+          )).map {
+          case stmt ~ rest => stmt :: rest
+        })
+    }
 
   private lazy val blockStatements: P[List[Statement]] =
     blockStatementsUntil(kw("end"))
@@ -1015,39 +1467,57 @@ object RubySubsetParser {
 
   private lazy val beginStmt: P[Statement] =
     (
-      kw("begin") ~ statementSep.* ~
-      blockStatementsUntil(kw("rescue") / kw("else") / kw("ensure") / kw("end")) ~
-      statementSep.* ~
-      rescueClause.* ~
-      statementSep.* ~
-      (kw("else") ~ statementSep.* ~ blockStatementsUntil(kw("ensure") / kw("end"))).? ~
-      statementSep.* ~
-      (kw("ensure") ~ statementSep.* ~ blockStatementsUntil(kw("end"))).? ~
-      statementSep.* ~ kw("end")
+      kw("begin") ~ (
+        statementSep.* ~
+        blockStatementsUntil(kw("rescue") / kw("else") / kw("ensure") / kw("end")) ~
+        statementSep.* ~
+        rescueClause.* ~
+        statementSep.* ~
+        (kw("else") ~ statementSep.* ~ blockStatementsUntil(kw("ensure") / kw("end"))).? ~
+        statementSep.* ~
+        (kw("ensure") ~ statementSep.* ~ blockStatementsUntil(kw("end"))).? ~
+        statementSep.* ~ kw("end")
+      ).cut
     ).map {
-      case _ ~ _ ~ body ~ _ ~ rescues ~ _ ~ elseOpt ~ _ ~ ensureOpt ~ _ ~ _ =>
+      case _ ~ (_ ~ body ~ _ ~ rescues ~ _ ~ elseOpt ~ _ ~ ensureOpt ~ _ ~ _) =>
         val elseBody = elseOpt.map { case _ ~ _ ~ statements => statements }.getOrElse(Nil)
         val ensureBody = ensureOpt.map { case _ ~ _ ~ statements => statements }.getOrElse(Nil)
         BeginRescue(body, rescues, elseBody, ensureBody)
     }
 
-  private lazy val defStmt: P[Statement] =
+  private lazy val defEndlessStmt: P[Statement] =
     (
       kw("def") ~
       defName ~
       (params / bareParams).? ~
-      statementSep.* ~
-      blockStatementsUntil(kw("rescue") / kw("else") / kw("ensure") / kw("end")) ~
-      statementSep.* ~
-      rescueClause.* ~
-      statementSep.* ~
-      (kw("else") ~ statementSep.* ~ blockStatementsUntil(kw("ensure") / kw("end"))).? ~
-      statementSep.* ~
-      (kw("ensure") ~ statementSep.* ~ blockStatementsUntil(kw("end"))).? ~
-      statementSep.* ~
-      kw("end")
+      sym("=") ~
+      spacing ~
+      refer(expr)
     ).map {
-      case _ ~ name ~ maybeParams ~ _ ~ body ~ _ ~ rescues ~ _ ~ elseOpt ~ _ ~ ensureOpt ~ _ ~ _ =>
+      case _ ~ name ~ maybeParams ~ _ ~ _ ~ bodyExpr =>
+        Def(name, maybeParams.getOrElse(Nil), List(ExprStmt(bodyExpr)))
+    }
+
+  private lazy val defStmt: P[Statement] =
+    defEndlessStmt /
+      (
+      kw("def") ~
+      defName ~
+      (
+        (params / bareParams).? ~
+        statementSep.* ~
+        blockStatementsUntil(kw("rescue") / kw("else") / kw("ensure") / kw("end")) ~
+        statementSep.* ~
+        rescueClause.* ~
+        statementSep.* ~
+        (kw("else") ~ statementSep.* ~ blockStatementsUntil(kw("ensure") / kw("end"))).? ~
+        statementSep.* ~
+        (kw("ensure") ~ statementSep.* ~ blockStatementsUntil(kw("end"))).? ~
+        statementSep.* ~
+        kw("end")
+      ).cut
+    ).map {
+      case _ ~ name ~ (maybeParams ~ _ ~ body ~ _ ~ rescues ~ _ ~ elseOpt ~ _ ~ ensureOpt ~ _ ~ _) =>
         val elseBody = elseOpt.map { case _ ~ _ ~ statements => statements }.getOrElse(Nil)
         val ensureBody = ensureOpt.map { case _ ~ _ ~ statements => statements }.getOrElse(Nil)
         val statements =
@@ -1059,56 +1529,74 @@ object RubySubsetParser {
         Def(name, maybeParams.getOrElse(Nil), statements)
     }
 
-  private lazy val singletonClassStmt: P[Statement] =
+  private lazy val singletonClassExpr: P[Expr] =
     (kw("class") ~ sym("<<") ~ refer(expr) ~ statementSep.* ~ blockStatements ~ statementSep.* ~ kw("end")).map {
       case _ ~ _ ~ receiver ~ _ ~ body ~ _ ~ _ =>
-        SingletonClassDef(receiver, body)
+        SingletonClassExpr(receiver, body)
+    }
+
+  private lazy val singletonClassStmt: P[Statement] =
+    (kw("class") ~ sym("<<") ~ refer(expr) ~ statementSep.* ~ blockStatements ~ statementSep.* ~ kw("end") ~ callSuffix.*).map {
+      case _ ~ _ ~ receiver ~ _ ~ body ~ _ ~ _ ~ suffixes =>
+        if(suffixes.isEmpty) {
+          SingletonClassDef(receiver, body)
+        } else {
+          val base: Expr = SingletonClassExpr(receiver, body)
+          ExprStmt(suffixes.foldLeft(base)((current, suffix) => suffix(current)))
+        }
+    }
+
+  private lazy val forBindingNames: P[String] =
+    (identifier ~ (sym(",") ~ identifier).*).map {
+      case first ~ rest => (first :: rest.map(_._2)).mkString(",")
     }
 
   private lazy val forStmt: P[Statement] =
-    (kw("for") ~ identifier ~ kw("in") ~ refer(expr) ~ statementSep.* ~ blockStatements ~ statementSep.* ~ kw("end")).map {
-      case _ ~ name ~ _ ~ iterable ~ _ ~ body ~ _ ~ _ =>
+    (kw("for") ~ (forBindingNames ~ kw("in") ~ refer(conditionExpr) ~ kw("do").? ~ statementSep.* ~ blockStatements ~ statementSep.* ~ kw("end")).cut).map {
+      case _ ~ (name ~ _ ~ iterable ~ _ ~ _ ~ body ~ _ ~ _) =>
         ForIn(name, iterable, body)
     }
 
   private lazy val whenClause: P[WhenClause] =
-    (kw("when") ~ sepBy1(refer(expr), sym(",")) ~ statementSep.* ~ blockStatementsUntil(kw("when") / kw("else") / kw("end")) ~ statementSep.*).map {
-      case _ ~ patterns ~ _ ~ body ~ _ => WhenClause(patterns, body)
+    ((kw("when") / kw("in")) ~ sepBy1(refer(expr), sym(",")) ~ (kw("then") / sym(";")).? ~ statementSep.* ~ blockStatementsUntil(kw("when") / kw("in") / kw("else") / kw("end")) ~ statementSep.*).map {
+      case _ ~ patterns ~ _ ~ _ ~ body ~ _ => WhenClause(patterns, body)
     }
 
   private lazy val caseStmt: P[Statement] =
     (
-      kw("case") ~ refer(expr).? ~ statementSep.* ~ whenClause.+ ~
-      statementSep.* ~
-      (kw("else") ~ statementSep.* ~ blockStatementsUntil(kw("end"))).? ~
-      statementSep.* ~ kw("end")
+      kw("case") ~ (
+        refer(expr).? ~ statementSep.* ~ whenClause.+ ~
+        statementSep.* ~
+        (kw("else") ~ statementSep.* ~ blockStatementsUntil(kw("end"))).? ~
+        statementSep.* ~ kw("end")
+      ).cut
     ).map {
-      case _ ~ scrutinee ~ _ ~ whens ~ _ ~ elseOpt ~ _ ~ _ =>
+      case _ ~ (scrutinee ~ _ ~ whens ~ _ ~ elseOpt ~ _ ~ _) =>
         val elseBody = elseOpt.map { case _ ~ _ ~ body => body }.getOrElse(Nil)
         CaseExpr(scrutinee, whens, elseBody)
     }
 
   private lazy val whileStmt: P[Statement] =
-    (kw("while") ~ refer(expr) ~ statementSep.* ~ blockStatements ~ statementSep.* ~ kw("end")).map {
-      case _ ~ condition ~ _ ~ body ~ _ ~ _ =>
+    (kw("while") ~ (refer(conditionExpr) ~ (kw("do") / kw("then")).? ~ statementSep.* ~ blockStatements ~ statementSep.* ~ kw("end")).cut).map {
+      case _ ~ (condition ~ _ ~ _ ~ body ~ _ ~ _) =>
         WhileExpr(condition, body)
     }
 
   private lazy val untilStmt: P[Statement] =
-    (kw("until") ~ refer(expr) ~ statementSep.* ~ blockStatements ~ statementSep.* ~ kw("end")).map {
-      case _ ~ condition ~ _ ~ body ~ _ ~ _ =>
+    (kw("until") ~ (refer(conditionExpr) ~ (kw("do") / kw("then")).? ~ statementSep.* ~ blockStatements ~ statementSep.* ~ kw("end")).cut).map {
+      case _ ~ (condition ~ _ ~ _ ~ body ~ _ ~ _) =>
         UntilExpr(condition, body)
     }
 
   private lazy val classStmt: P[Statement] =
-    (kw("class") ~ constPathSegments ~ (sym("<") ~ refer(expr)).?.map(_.map(_._2)) ~ statementSep.* ~ blockStatements ~ statementSep.* ~ kw("end")).map {
-      case _ ~ name ~ superClass ~ _ ~ body ~ _ ~ _ =>
+    (kw("class") ~ constPathSegments ~ ((sym("<") ~ refer(expr)).?.map(_.map(_._2)) ~ statementSep.* ~ blockStatements ~ statementSep.* ~ kw("end")).cut).map {
+      case _ ~ name ~ (superClass ~ _ ~ body ~ _ ~ _) =>
         ClassDef(name.mkString("::"), body, UnknownSpan, superClass)
     }
 
   private lazy val moduleStmt: P[Statement] =
-    (kw("module") ~ constPathSegments ~ statementSep.* ~ blockStatements ~ statementSep.* ~ kw("end")).map {
-      case _ ~ name ~ _ ~ body ~ _ ~ _ =>
+    (kw("module") ~ constPathSegments ~ (statementSep.* ~ blockStatements ~ statementSep.* ~ kw("end")).cut).map {
+      case _ ~ name ~ (_ ~ body ~ _ ~ _) =>
         ModuleDef(name.mkString("::"), body)
     }
 
@@ -1141,35 +1629,41 @@ object RubySubsetParser {
       }
 
   private lazy val ifTail: P[List[Statement]] =
-    (
-      kw("elsif") ~ refer(expr) ~ statementSep.* ~ blockStatementsUntil(kw("elsif") / kw("else") / kw("end")) ~ statementSep.* ~ refer(ifTail)
-    ).map {
-      case _ ~ condition ~ _ ~ body ~ _ ~ tail =>
-        List(IfExpr(condition, body, tail))
-    } /
-      (kw("else") ~ statementSep.* ~ blockStatementsUntil(kw("end"))).map {
-        case _ ~ _ ~ elseBody => elseBody
+    guarded("ifTail") {
+      (
+        kw("elsif") ~ refer(expr) ~ statementSep.* ~ blockStatementsUntil(kw("elsif") / kw("else") / kw("end")) ~ statementSep.* ~ refer(ifTail)
+      ).map {
+        case _ ~ condition ~ _ ~ body ~ _ ~ tail =>
+          List(IfExpr(condition, body, tail))
       } /
-      (kw("end").and ~> success(Nil))
+        (kw("else") ~ statementSep.* ~ blockStatementsUntil(kw("end"))).map {
+          case _ ~ _ ~ elseBody => elseBody
+        } /
+        (kw("end").and ~> success(Nil))
+    }
 
   private lazy val ifStmt: P[Statement] =
     (
-      kw("if") ~ refer(expr) ~ statementSep.* ~ blockStatementsUntil(kw("elsif") / kw("else") / kw("end")) ~
-      statementSep.* ~ refer(ifTail) ~
-      statementSep.* ~ kw("end")
+      kw("if") ~ (
+        refer(expr) ~ kw("then").? ~ statementSep.* ~ blockStatementsUntil(kw("elsif") / kw("else") / kw("end")) ~
+        statementSep.* ~ refer(ifTail) ~
+        statementSep.* ~ kw("end")
+      ).cut
     ).map {
-      case _ ~ condition ~ _ ~ thenBody ~ _ ~ elseBody ~ _ ~ _ =>
+      case _ ~ (condition ~ _ ~ _ ~ thenBody ~ _ ~ elseBody ~ _ ~ _) =>
         IfExpr(condition, thenBody, elseBody)
     }
 
   private lazy val unlessStmt: P[Statement] =
     (
-      kw("unless") ~ refer(expr) ~ statementSep.* ~ blockStatementsUntil(kw("else") / kw("end")) ~
-      statementSep.* ~
-      (kw("else") ~ statementSep.* ~ blockStatementsUntil(kw("end"))).? ~
-      statementSep.* ~ kw("end")
+      kw("unless") ~ (
+        refer(expr) ~ kw("then").? ~ statementSep.* ~ blockStatementsUntil(kw("else") / kw("end")) ~
+        statementSep.* ~
+        (kw("else") ~ statementSep.* ~ blockStatementsUntil(kw("end"))).? ~
+        statementSep.* ~ kw("end")
+      ).cut
     ).map {
-      case _ ~ condition ~ _ ~ thenBody ~ _ ~ elseBodyOpt ~ _ ~ _ =>
+      case _ ~ (condition ~ _ ~ _ ~ thenBody ~ _ ~ elseBodyOpt ~ _ ~ _) =>
         val elseBody = elseBodyOpt.map { case _ ~ _ ~ body => body }.getOrElse(Nil)
         UnlessExpr(condition, thenBody, elseBody)
     }
@@ -1177,18 +1671,30 @@ object RubySubsetParser {
   private lazy val program: P[Program] =
     (spacing ~> (topLevelStatements <~ statementSep.*) <~ spacing).map(stmts => Program(stmts))
 
-  private def encodeDoubleQuoted(value: String): String =
-    "\"" + value.flatMap {
-      case '\\' => "\\\\"
-      case '"' => "\\\""
-      case '\n' => "\\n"
-      case '\r' => "\\r"
-      case '\t' => "\\t"
-      case c => c.toString
-    } + "\""
+  private def encodeDoubleQuoted(value: String): String = {
+    val builder = new StringBuilder("\"")
+    var index = 0
+    while(index < value.length) {
+      val c = value.charAt(index)
+      c match {
+        case '\\' => builder.append("\\\\")
+        case '"' => builder.append("\\\"")
+        case '\n' => builder.append("\\n")
+        case '\r' => builder.append("\\r")
+        case '\t' => builder.append("\\t")
+        // Keep heredoc payload literal after normalization.
+        case '#' if index + 1 < value.length && value.charAt(index + 1) == '{' =>
+          builder.append("\\#")
+        case _ =>
+          builder.append(c)
+      }
+      index += 1
+    }
+    builder.append("\"").toString
+  }
 
   private def normalizeHeredoc(input: String): String = {
-    val heredocPattern = raw"""(?<![\w\)\]\}])<<([~-]?)(?:'([^'\n]+)'|"([^"\n]+)"|`([^`\n]+)`|([A-Za-z_][A-Za-z0-9_]*))""".r
+    val heredocPattern = raw"""(?<![\w\)\]\}'\x22\x60\\])<<([~-]?)(?:'([^'\n]+)'|"([^"\n]+)"|`([^`\n]+)`|([A-Za-z_][A-Za-z0-9_]*))""".r
     val outputLines = scala.collection.mutable.ArrayBuffer.empty[String]
     val replacements = scala.collection.mutable.ArrayBuffer.empty[(String, String)]
     val pending = scala.collection.mutable.Queue.empty[PendingHeredoc]
@@ -1255,8 +1761,14 @@ object RubySubsetParser {
     } else input
   }
 
+  private def stripEndMarker(input: String): String = {
+    val lines = input.split("\n", -1)
+    val endIdx = lines.indexWhere(_ == "__END__")
+    if(endIdx >= 0) lines.take(endIdx).mkString("\n") else input
+  }
+
   def parse(input: String): Either[String, Program] = {
-    val normalized = normalizeHeredoc(stripXOptionPreamble(input))
+    val normalized = normalizeHeredoc(stripXOptionPreamble(stripEndMarker(input)))
     parseAll(program, normalized).left.map(f => formatFailure(normalized, f))
   }
 }

--- a/src/main/scala/com/github/kmizu/macro_peg/ruby/RubySubsetParser.scala
+++ b/src/main/scala/com/github/kmizu/macro_peg/ruby/RubySubsetParser.scala
@@ -138,6 +138,7 @@ object RubySubsetParser {
       ("$".s ~ identifierRaw).map { case _ ~ name => s"$$$name" } /
         ("$".s ~ range('0' to '9').+).map { case _ ~ digits => s"$$${digits.mkString}" } /
         "$!".s /
+        "$?".s /
         "$@".s /
         "$&".s /
         "$`".s /
@@ -165,7 +166,13 @@ object RubySubsetParser {
     }
 
   private lazy val integerLiteral: P[Expr] =
-    token(range('0' to '9').+).map(ds => IntLiteral(ds.mkString.toLong))
+    token((range('0' to '9').+ <~ !(".".s ~ range('0' to '9')))).map(ds => IntLiteral(ds.mkString.toLong))
+
+  private lazy val floatLiteral: P[Expr] =
+    token((range('0' to '9').+ ~ ".".s ~ range('0' to '9').+)).map {
+      case intPart ~ _ ~ fracPart =>
+        FloatLiteral(s"${intPart.mkString}.${fracPart.mkString}".toDouble)
+    }
 
   private lazy val escapedChar: P[String] =
     ("\\".s ~ any).map {
@@ -444,7 +451,9 @@ object RubySubsetParser {
     }
 
   private lazy val primaryNoCall: P[Expr] =
-    integerLiteral /
+    lambdaLiteral /
+      integerLiteral /
+      floatLiteral /
       stringLiteral /
       singleQuotedStringLiteral /
       backtickLiteral /
@@ -470,10 +479,16 @@ object RubySubsetParser {
   private lazy val positionalParam: P[String] =
     (identifier ~ (sym("=") ~ refer(expr)).?).map(_._1)
 
+  private lazy val keywordParam: P[String] =
+    ((identifierNoSpace <~ sym(":")) ~ refer(expr).?).map {
+      case name ~ _ => s"$name:"
+    }
+
   private lazy val formalParam: P[String] =
     (sym("**") ~ identifier).map { case _ ~ name => s"**$name" } /
       (sym("*") ~ identifier).map { case _ ~ name => s"*$name" } /
       (sym("&") ~ identifier).map { case _ ~ name => s"&$name" } /
+      keywordParam /
       positionalParam
 
   private lazy val blockParams: P[List[String]] =
@@ -505,6 +520,13 @@ object RubySubsetParser {
 
   private lazy val blockLiteral: P[Block] =
     doBlock / braceBlock
+
+  private lazy val lambdaLiteral: P[Expr] =
+    (sym("->") ~ (params / bareParams).? ~ blockLiteral).map {
+      case _ ~ maybeParams ~ block =>
+        val lambdaParams = maybeParams.getOrElse(block.params)
+        LambdaLiteral(lambdaParams, block.body)
+    }
 
   private lazy val lineBreak: P[Unit] =
     ("\n".s ~ inlineSpacing).void
@@ -606,7 +628,7 @@ object RubySubsetParser {
       (postfixExpr <~ horizontalSpacing)
 
   private lazy val mulDivExpr: P[Expr] =
-    chainl(unaryExpr)(infix("*") / infix("/"))
+    chainl(unaryExpr)(infix("*") / infix("/") / infix("%"))
 
   private lazy val addSubExpr: P[Expr] =
     chainl(mulDivExpr)(infix("+") / infix("-"))
@@ -770,8 +792,14 @@ object RubySubsetParser {
       case name ~ _ ~ value => Assign(name, value)
     }
 
+  private lazy val returnValueExpr: P[Expr] =
+    sepBy1(refer(expr), sym(",")).map {
+      case value :: Nil => value
+      case values => ArrayLiteral(values)
+    }
+
   private lazy val returnStmt: P[Statement] =
-    (kw("return") ~ refer(expr).?).map {
+    (kw("return") ~ returnValueExpr.?).map {
       case _ ~ value => Return(value)
     }
 
@@ -796,30 +824,49 @@ object RubySubsetParser {
       methodIdentifier
 
   private lazy val simpleStatement: P[Statement] =
-    ((returnStmt / retryStmt / logicalAssignStmt / compoundAssignStmt / constAssignStmt / multiAssignStmt / assignStmt / chainedCommandCall.map(ExprStmt(_)) / receiverCommandCall.map(ExprStmt(_)) / commandCall.map(ExprStmt(_)) / refer(expr).map(ExprStmt(_))) ~ (inlineSpacing ~> modifierSuffix).?).map {
-      case stmt ~ Some(modifier) => modifier(stmt)
-      case stmt ~ None => stmt
-    }
+    returnStmt /
+      retryStmt /
+      logicalAssignStmt /
+      compoundAssignStmt /
+      constAssignStmt /
+      multiAssignStmt /
+      assignStmt /
+      chainedCommandCall.map(ExprStmt(_)) /
+      receiverCommandCall.map(ExprStmt(_)) /
+      commandCall.map(ExprStmt(_)) /
+      refer(expr).map(ExprStmt(_))
 
-  private lazy val statement: P[Statement] =
-    refer(beginStmt) /
-    refer(whileStmt) /
-    refer(untilStmt) /
-    refer(forStmt) /
-    refer(caseStmt) /
-    refer(defStmt) /
+  private lazy val statementBase: P[Statement] =
+    (
+      refer(beginStmt) /
+      refer(whileStmt) /
+      refer(untilStmt) /
+      refer(forStmt) /
+      refer(caseStmt) /
+      refer(defStmt) /
       refer(singletonClassStmt) /
       refer(classStmt) /
       refer(moduleStmt) /
       refer(ifStmt) /
       refer(unlessStmt) /
       simpleStatement
+    )
+
+  private lazy val statement: P[Statement] =
+    (statementBase ~ (inlineSpacing ~> modifierSuffix).?).map {
+      case stmt ~ Some(modifier) => modifier(stmt)
+      case stmt ~ None => stmt
+    }
 
   private lazy val topLevelStatements: P[List[Statement]] =
     sepBy0(refer(statement), statementSep)
 
   private def blockStatementsUntil(stop: P[Any]): P[List[Statement]] =
-    (stop.and ~> success(Nil)) / sepBy1(refer(statement), statementSep)
+    (stop.and ~> success(Nil)) /
+      ((refer(statement) ~ (statementSep.+ ~> refer(blockStatementsUntil(stop))).?).map {
+        case stmt ~ Some(rest) => stmt :: rest
+        case stmt ~ None => List(stmt)
+      })
 
   private lazy val blockStatements: P[List[Statement]] =
     blockStatementsUntil(kw("end"))
@@ -860,17 +907,25 @@ object RubySubsetParser {
       defName ~
       (params / bareParams).? ~
       statementSep.* ~
-      blockStatementsUntil(kw("ensure") / kw("end")) ~
+      blockStatementsUntil(kw("rescue") / kw("else") / kw("ensure") / kw("end")) ~
+      statementSep.* ~
+      rescueClause.* ~
+      statementSep.* ~
+      (kw("else") ~ statementSep.* ~ blockStatementsUntil(kw("ensure") / kw("end"))).? ~
       statementSep.* ~
       (kw("ensure") ~ statementSep.* ~ blockStatementsUntil(kw("end"))).? ~
       statementSep.* ~
       kw("end")
     ).map {
-      case _ ~ name ~ maybeParams ~ _ ~ body ~ _ ~ ensureOpt ~ _ ~ _ =>
-        val statements = ensureOpt match {
-          case Some(_ ~ _ ~ ensureBody) => List(BeginRescue(body, Nil, Nil, ensureBody))
-          case None => body
-        }
+      case _ ~ name ~ maybeParams ~ _ ~ body ~ _ ~ rescues ~ _ ~ elseOpt ~ _ ~ ensureOpt ~ _ ~ _ =>
+        val elseBody = elseOpt.map { case _ ~ _ ~ statements => statements }.getOrElse(Nil)
+        val ensureBody = ensureOpt.map { case _ ~ _ ~ statements => statements }.getOrElse(Nil)
+        val statements =
+          if(rescues.nonEmpty || elseBody.nonEmpty || ensureBody.nonEmpty) {
+            List(BeginRescue(body, rescues, elseBody, ensureBody))
+          } else {
+            body
+          }
         Def(name, maybeParams.getOrElse(Nil), statements)
     }
 
@@ -935,6 +990,24 @@ object RubySubsetParser {
       (kw("unless") ~ refer(expr)).map {
         case _ ~ condition =>
           (stmt: Statement) => UnlessExpr(condition, List(stmt), Nil)
+      } /
+      (kw("rescue") ~ refer(expr)).map {
+        case _ ~ fallback =>
+          (stmt: Statement) =>
+            BeginRescue(
+              List(stmt),
+              List(RescueClause(Nil, None, List(ExprStmt(fallback)))),
+              Nil,
+              Nil
+            )
+      } /
+      (kw("while") ~ refer(expr)).map {
+        case _ ~ condition =>
+          (stmt: Statement) => WhileExpr(condition, List(stmt))
+      } /
+      (kw("until") ~ refer(expr)).map {
+        case _ ~ condition =>
+          (stmt: Statement) => UntilExpr(condition, List(stmt))
       }
 
   private lazy val ifTail: P[List[Statement]] =

--- a/src/main/scala/com/github/kmizu/macro_peg/ruby/RubySubsetParser.scala
+++ b/src/main/scala/com/github/kmizu/macro_peg/ruby/RubySubsetParser.scala
@@ -5,7 +5,12 @@ import com.github.kmizu.macro_peg.ruby.RubyAst._
 
 object RubySubsetParser {
   private type P[+A] = MacroParser[A]
-  private case class PendingHeredoc(token: String, terminator: String, lines: scala.collection.mutable.ArrayBuffer[String])
+  private case class PendingHeredoc(
+    token: String,
+    terminator: String,
+    allowIndentedTerminator: Boolean,
+    lines: scala.collection.mutable.ArrayBuffer[String]
+  )
 
   private lazy val horizontalSpaceChar: P[Unit] =
     range(' ' to ' ', '\t' to '\t', '\r' to '\r').map(_ => ())
@@ -21,6 +26,9 @@ object RubySubsetParser {
 
   private lazy val inlineSpacing: P[Unit] =
     (horizontalSpaceChar / comment / blockComment).*.void
+
+  private lazy val horizontalSpacing: P[Unit] =
+    horizontalSpaceChar.*.void
 
   private lazy val spacing: P[Unit] =
     (horizontalSpaceChar / newlineChar / comment / blockComment).*.void
@@ -62,6 +70,7 @@ object RubySubsetParser {
       "elsif".s /
       "else".s /
       "and".s /
+      "not".s /
       "or".s /
       "do".s /
       "rescue".s /
@@ -85,22 +94,29 @@ object RubySubsetParser {
   private lazy val methodSuffixChar: P[String] =
     "?".s / "!".s / "=".s
 
-  private lazy val methodIdentifierRaw: P[String] =
-    (identifierRaw ~ methodSuffixChar.?).map {
-      case base ~ Some(suffix) => base + suffix
-      case base ~ None => base
+  private lazy val methodIdentifierWithSuffixRaw: P[String] =
+    (identifierRaw ~ methodSuffixChar).map {
+      case base ~ suffix => base + suffix
     }
 
+  private lazy val methodIdentifierRaw: P[String] =
+    methodIdentifierWithSuffixRaw /
+      (!reservedWord ~ identifierRaw).map(_._2)
+
   private lazy val methodIdentifierNoSpace: P[String] =
-    (!reservedWord ~ methodIdentifierRaw).map(_._2)
+    methodIdentifierRaw
 
   private lazy val methodIdentifier: P[String] =
     token(methodIdentifierNoSpace)
 
+  private lazy val keywordMethodNameNoSpace: P[String] =
+    "class".s
+
+  private lazy val receiverMethodNameNoSpace: P[String] =
+    methodIdentifierNoSpace / keywordMethodNameNoSpace
+
   private lazy val punctuatedMethodIdentifierNoSpace: P[String] =
-    (!reservedWord ~ (identifierRaw ~ methodSuffixChar)).map {
-      case _ ~ (base ~ suffix) => base + suffix
-    }
+    methodIdentifierWithSuffixRaw
 
   private lazy val punctuatedMethodIdentifier: P[String] =
     token(punctuatedMethodIdentifierNoSpace)
@@ -161,11 +177,34 @@ object RubySubsetParser {
       case _ ~ c => c
     }
 
+  private lazy val escapedAnyChar: P[String] =
+    ("\\".s ~ any).map { case _ ~ c => s"\\$c" }
+
+  private def quotedInInterpolation(delim: String): P[String] =
+    (delim.s ~ (escapedAnyChar / (!delim.s ~ any).map(_._2)).* ~ delim.s).map {
+      case open ~ chars ~ close => open + chars.mkString + close
+    }
+
+  private lazy val interpolationSegment: P[String] = {
+    lazy val interpolationChunk: P[String] =
+      quotedInInterpolation("\"") /
+        quotedInInterpolation("'") /
+        ("{".s ~ refer(interpolationChunk).* ~ "}".s).map {
+          case open ~ inner ~ close => open + inner.mkString + close
+        } /
+        (!"}".s ~ any).map(_._2)
+    ("#{".s ~ interpolationChunk.* ~ "}".s).map {
+      case open ~ chunks ~ close => open + chunks.mkString + close
+    }
+  }
+
   private lazy val plainStringChar: P[String] =
-    (!"\"".s ~ any).map(_._2)
+    (!"\"".s ~ !"\\".s ~ !"#{".s ~ any).map {
+      case _ ~ _ ~ _ ~ char => char
+    }
 
   private lazy val stringLiteral: P[Expr] =
-    token(("\"".s ~ (escapedChar / plainStringChar).* ~ "\"".s).map {
+    token(("\"".s ~ (escapedChar / interpolationSegment / plainStringChar).* ~ "\"".s).map {
       case _ ~ chars ~ _ => StringLiteral(chars.mkString)
     })
 
@@ -181,6 +220,16 @@ object RubySubsetParser {
 
   private lazy val singleQuotedStringLiteral: P[Expr] =
     token(("'".s ~ (escapedSingleQuotedChar / plainSingleQuotedChar).* ~ "'".s).map {
+      case _ ~ chars ~ _ => StringLiteral(chars.mkString)
+    })
+
+  private lazy val plainBacktickChar: P[String] =
+    (!"`".s ~ !"\\".s ~ !"#{".s ~ any).map {
+      case _ ~ _ ~ _ ~ char => char
+    }
+
+  private lazy val backtickLiteral: P[Expr] =
+    token(("`".s ~ (escapedChar / interpolationSegment / plainBacktickChar).* ~ "`".s).map {
       case _ ~ chars ~ _ => StringLiteral(chars.mkString)
     })
 
@@ -327,7 +376,7 @@ object RubySubsetParser {
       (refer(expr) ~ sym("=>") ~ refer(expr)).map { case key ~ _ ~ value => key -> value }
 
   private lazy val hashLiteral: P[Expr] =
-    (sym("{") ~> spacing ~> sepBy0(hashEntry, sym(",")) <~ spacing <~ sym("}")).map(HashLiteral(_))
+    (sym("{") ~> spacing ~> sepBy0(spacing ~> hashEntry <~ spacing, sym(",")) <~ spacing <~ sym("}")).map(HashLiteral(_))
 
   private lazy val callArgs: P[List[Expr]] =
     sym("(") ~> spacing ~> sepBy0(spacing ~> callArgExpr <~ spacing, sym(",")) <~ spacing <~ sym(")")
@@ -336,7 +385,14 @@ object RubySubsetParser {
     sepBy1(callArgExpr, sym(","))
 
   private lazy val blockPassArgExpr: P[Expr] =
-    (sym("&") ~ identifier).map { case _ ~ name => LocalVar(s"&$name") }
+    (sym("&") ~ identifier).map { case _ ~ name => LocalVar(s"&$name") } /
+      (sym("&") ~ symbolLiteral).map { case _ ~ symbol => symbol }
+
+  private lazy val doubleSplatArgExpr: P[Expr] =
+    (sym("**") ~ refer(expr)).map(_._2)
+
+  private lazy val splatArgExpr: P[Expr] =
+    (sym("*") ~ refer(expr)).map(_._2)
 
   private lazy val keywordArgExpr: P[Expr] =
     ((identifierNoSpace <~ sym(":")) ~ refer(expr)).map {
@@ -345,7 +401,7 @@ object RubySubsetParser {
     }
 
   private lazy val callArgExpr: P[Expr] =
-    blockPassArgExpr / keywordArgExpr / refer(expr)
+    blockPassArgExpr / doubleSplatArgExpr / splatArgExpr / keywordArgExpr / refer(expr)
 
   private lazy val functionCall: P[Expr] =
     (methodIdentifier ~ callArgs).map { case name ~ args => Call(None, name, args) }
@@ -354,15 +410,15 @@ object RubySubsetParser {
     constRef / selfExpr / variable
 
   private lazy val receiverCommandHead: P[Expr ~ String] =
-    (receiverForCommand <~ sym(".")) ~ methodIdentifierNoSpace
+    (receiverForCommand <~ sym(".")) ~ receiverMethodNameNoSpace
 
   private lazy val commandCall: P[Expr] =
-    ((methodIdentifierNoSpace <~ spacing1) ~ commandArgs).map {
+    ((((methodIdentifierNoSpace <~ spacing1) ~ commandArgs.and).and ~> (methodIdentifierNoSpace <~ spacing1)) ~ commandArgs).map {
       case name ~ args => Call(None, name, args)
     }
 
   private lazy val receiverCommandCall: P[Expr] =
-    ((receiverCommandHead <~ spacing1) ~ commandArgs).map {
+    ((((receiverCommandHead <~ spacing1) ~ commandArgs.and).and ~> (receiverCommandHead <~ spacing1)) ~ commandArgs).map {
       case receiverAndMethod ~ args =>
         val receiver ~ methodName = receiverAndMethod
         Call(Some(receiver), methodName, args)
@@ -373,10 +429,25 @@ object RubySubsetParser {
       case receiver ~ methodName => Call(Some(receiver), methodName, Nil)
     }
 
+  private def appendCommandArgs(target: Expr, args: List[Expr]): Expr =
+    target match {
+      case call @ Call(receiver, methodName, existingArgs, span) =>
+        if(existingArgs.isEmpty) Call(receiver, methodName, args, span)
+        else Call(Some(call), "call", args)
+      case other =>
+        Call(Some(other), "call", args)
+    }
+
+  private lazy val chainedCommandCall: P[Expr] =
+    ((((chainedCallExpr <~ spacing1) ~ commandArgs.and).and ~> (chainedCallExpr <~ spacing1)) ~ commandArgs).map {
+      case call ~ args => appendCommandArgs(call, args)
+    }
+
   private lazy val primaryNoCall: P[Expr] =
     integerLiteral /
       stringLiteral /
       singleQuotedStringLiteral /
+      backtickLiteral /
       percentQuotedStringLiteral /
       percentWordArray /
       regexLiteral /
@@ -400,20 +471,36 @@ object RubySubsetParser {
     (identifier ~ (sym("=") ~ refer(expr)).?).map(_._1)
 
   private lazy val formalParam: P[String] =
-    (sym("&") ~ identifier).map { case _ ~ name => s"&$name" } /
+    (sym("**") ~ identifier).map { case _ ~ name => s"**$name" } /
+      (sym("*") ~ identifier).map { case _ ~ name => s"*$name" } /
+      (sym("&") ~ identifier).map { case _ ~ name => s"&$name" } /
       positionalParam
 
   private lazy val blockParams: P[List[String]] =
     sym("|") ~> sepBy0(formalParam, sym(",")) <~ sym("|")
 
   private lazy val doBlock: P[Block] =
-    (kw("do") ~ blockParams.? ~ statementSep.* ~ blockStatementsUntil(kw("end")) ~ statementSep.* ~ kw("end")).map {
-      case _ ~ maybeParams ~ _ ~ body ~ _ ~ _ => Block(maybeParams.getOrElse(Nil), body)
+    (
+      kw("do") ~
+      blockParams.? ~
+      statementSep.* ~
+      blockStatementsUntil(kw("ensure") / kw("end")) ~
+      statementSep.* ~
+      (kw("ensure") ~ statementSep.* ~ blockStatementsUntil(kw("end"))).? ~
+      statementSep.* ~
+      kw("end")
+    ).map {
+      case _ ~ maybeParams ~ _ ~ body ~ _ ~ ensureOpt ~ _ ~ _ =>
+        val statements = ensureOpt match {
+          case Some(_ ~ _ ~ ensureBody) => List(BeginRescue(body, Nil, Nil, ensureBody))
+          case None => body
+        }
+        Block(maybeParams.getOrElse(Nil), statements)
     }
 
   private lazy val braceBlock: P[Block] =
-    (sym("{") ~ blockParams.? ~ statementSep.* ~ blockStatementsUntil(sym("}")) ~ statementSep.* ~ sym("}")).map {
-      case _ ~ maybeParams ~ _ ~ body ~ _ ~ _ => Block(maybeParams.getOrElse(Nil), body)
+    (sym("{") ~ blockParams.? ~ statementSep.* ~ blockStatementsUntil(sym("}")) ~ statementSep.* ~ spacing ~ sym("}")).map {
+      case _ ~ maybeParams ~ _ ~ body ~ _ ~ _ ~ _ => Block(maybeParams.getOrElse(Nil), body)
     }
 
   private lazy val blockLiteral: P[Block] =
@@ -427,13 +514,14 @@ object RubySubsetParser {
 
   private lazy val blockCallExpr: P[Expr] =
     chainedCallExpr /
+      chainedCommandCall /
       receiverCommandNoArgs /
       receiverCommandCall /
       functionCall /
       commandCall
 
   private lazy val blockCallStmt: P[Statement] =
-    ((blockCallExpr <~ spacing) ~ blockLiteral).map {
+    ((((blockCallExpr <~ spacing) ~ blockLiteral.and).and ~> (blockCallExpr <~ spacing)) ~ blockLiteral).map {
       case call ~ block => ExprStmt(CallWithBlock(call, block))
     }
 
@@ -447,7 +535,7 @@ object RubySubsetParser {
       "%".s
 
   private lazy val suffixMethodName: P[String] =
-    methodIdentifier / token(operatorMethodName)
+    receiverMethodNameNoSpace / operatorMethodName
 
   private lazy val methodSuffix: P[Expr => Expr] =
     ((sym(".") / sym("&.")) ~ suffixMethodName ~ callArgs.?).map {
@@ -466,8 +554,21 @@ object RubySubsetParser {
     methodSuffix / indexSuffix / blockAttachSuffix
 
   private lazy val blockAttachSuffix: P[Expr => Expr] =
-    refer(blockLiteral).map { block =>
+    (inlineSpacing ~> refer(blockLiteral)).map { block =>
       (receiver: Expr) => CallWithBlock(receiver, block)
+    }
+
+  private lazy val nonIndexCallSuffix: P[Expr => Expr] =
+    methodSuffix / blockAttachSuffix
+
+  private lazy val postfixNoIndexExpr: P[Expr] =
+    ((functionCall / commandExpr / bareNoArgPunctuatedCall / primaryNoCall) ~ nonIndexCallSuffix.*).map {
+      case base ~ suffixes => suffixes.foldLeft(base)((current, suffix) => suffix(current))
+    }
+
+  private lazy val indexTarget: P[(Expr, List[Expr])] =
+    (postfixNoIndexExpr ~ sym("[") ~ spacing ~ sepBy0(spacedExpr, sym(",")) ~ spacing ~ sym("]")).map {
+      case receiver ~ _ ~ _ ~ args ~ _ ~ _ => receiver -> args
     }
 
   private lazy val postfixExpr: P[Expr] =
@@ -490,6 +591,9 @@ object RubySubsetParser {
     ((op.s <~ !identCont) <~ spacing).map(_ => (lhs: Expr, rhs: Expr) => BinaryOp(lhs, op, rhs))
 
   private lazy val unaryExpr: P[Expr] =
+    (kw("not") ~ refer(unaryExpr)).map {
+      case _ ~ target => UnaryOp("not", target)
+    } /
     (sym("!") ~ refer(unaryExpr)).map {
       case _ ~ target => UnaryOp("!", target)
     } /
@@ -498,8 +602,8 @@ object RubySubsetParser {
       } /
       (sym("+") ~ refer(unaryExpr)).map {
         case _ ~ target => UnaryOp("+", target)
-    } /
-      postfixExpr
+      } /
+      (postfixExpr <~ horizontalSpacing)
 
   private lazy val mulDivExpr: P[Expr] =
     chainl(unaryExpr)(infix("*") / infix("/"))
@@ -541,26 +645,44 @@ object RubySubsetParser {
     }
 
   private lazy val assignExpr: P[Expr] =
-    (assignableName ~ sym("=") ~ refer(expr)).map {
+    (((assignableName <~ sym("=").and).and ~> assignableName) ~ sym("=") ~ refer(expr)).map {
       case name ~ _ ~ value => AssignExpr(name, value)
     }
 
+  private lazy val receiverAssignableHead: P[Expr ~ String] =
+    (receiverForCommand <~ sym(".")) ~ identifier
+
   private lazy val receiverAssignExpr: P[Expr] =
-    ((receiverForCommand <~ sym(".")) ~ identifier ~ sym("=") ~ refer(expr)).map {
+    (((receiverAssignableHead <~ sym("=").and).and ~> receiverAssignableHead) ~ sym("=") ~ refer(expr)).map {
       case receiver ~ name ~ _ ~ value =>
         Call(Some(receiver), s"${name}=", List(value))
     }
 
   private lazy val receiverLogicalAssignExpr: P[Expr] =
-    ((receiverForCommand <~ sym(".")) ~ identifier ~ (sym("||=") / sym("&&=")) ~ refer(expr)).map {
+    (((receiverAssignableHead <~ (sym("||=") / sym("&&=")).and).and ~> receiverAssignableHead) ~ (sym("||=") / sym("&&=")) ~ refer(expr)).map {
       case receiver ~ name ~ op ~ value =>
         val lhs = Call(Some(receiver), name, Nil)
         val underlying = if(op == "||=") "||" else "&&"
         BinaryOp(lhs, underlying, value)
     }
 
+  private lazy val indexAssignExpr: P[Expr] =
+    (((indexTarget <~ sym("=").and).and ~> indexTarget) ~ sym("=") ~ refer(expr)).map {
+      case (receiver, args) ~ _ ~ value =>
+        Call(Some(receiver), "[]=", args :+ value)
+    }
+
+  private lazy val indexLogicalAssignExpr: P[Expr] =
+    (((indexTarget <~ (sym("||=") / sym("&&=")).and).and ~> indexTarget) ~ (sym("||=") / sym("&&=")) ~ refer(expr)).map {
+      case (receiver, args) ~ op ~ value =>
+        val lhs = Call(Some(receiver), "[]", args)
+        val underlying = if(op == "||=") "||" else "&&"
+        val rhs = BinaryOp(lhs, underlying, value)
+        Call(Some(receiver), "[]=", args :+ rhs)
+    }
+
   private lazy val receiverCompoundAssignExpr: P[Expr] =
-    ((receiverForCommand <~ sym(".")) ~ identifier ~ compoundAssignOperator ~ refer(expr)).map {
+    (((receiverAssignableHead <~ compoundAssignOperator.and).and ~> receiverAssignableHead) ~ compoundAssignOperator ~ refer(expr)).map {
       case receiver ~ name ~ op ~ value =>
         val underlying = op.dropRight(1)
         val lhs = Call(Some(receiver), name, Nil)
@@ -568,8 +690,30 @@ object RubySubsetParser {
         Call(Some(receiver), s"${name}=", List(rhs))
     }
 
+  private lazy val logicalAssignExpr: P[Expr] =
+    (((assignableName <~ (sym("||=") / sym("&&=")).and).and ~> assignableName) ~ (sym("||=") / sym("&&=")) ~ refer(expr)).map {
+      case name ~ op ~ value =>
+        val underlying = if(op == "||=") "||" else "&&"
+        AssignExpr(name, BinaryOp(assignableAsExpr(name), underlying, value))
+    }
+
+  private lazy val compoundAssignExpr: P[Expr] =
+    (((assignableName <~ compoundAssignOperator.and).and ~> assignableName) ~ compoundAssignOperator ~ refer(expr)).map {
+      case name ~ op ~ value =>
+        val underlying = op.dropRight(1)
+        AssignExpr(name, BinaryOp(assignableAsExpr(name), underlying, value))
+    }
+
   private lazy val expr: P[Expr] =
-    receiverAssignExpr / receiverLogicalAssignExpr / receiverCompoundAssignExpr / assignExpr / conditionalExpr
+    receiverAssignExpr /
+      receiverLogicalAssignExpr /
+      receiverCompoundAssignExpr /
+      indexLogicalAssignExpr /
+      indexAssignExpr /
+      logicalAssignExpr /
+      compoundAssignExpr /
+      assignExpr /
+      conditionalExpr
 
   private lazy val assignableName: P[String] =
     identifier / instanceVarName / classVarName / globalVarName
@@ -611,6 +755,21 @@ object RubySubsetParser {
       case name ~ _ ~ value => Assign(name, value)
     }
 
+  private lazy val multiAssignStmt: P[Statement] =
+    (assignableName ~ (sym(",") ~ assignableName).+ ~ sym("=") ~ refer(expr)).map {
+      case first ~ rest ~ _ ~ value =>
+        val names = first :: rest.map(_._2)
+        MultiAssign(names, value)
+    }
+
+  private lazy val constAssignName: P[String] =
+    constPathSegments.map(_.mkString("::"))
+
+  private lazy val constAssignStmt: P[Statement] =
+    (((constAssignName <~ sym("=").and).and ~> constAssignName) ~ sym("=") ~ refer(expr)).map {
+      case name ~ _ ~ value => Assign(name, value)
+    }
+
   private lazy val returnStmt: P[Statement] =
     (kw("return") ~ refer(expr).?).map {
       case _ ~ value => Return(value)
@@ -621,6 +780,9 @@ object RubySubsetParser {
 
   private lazy val params: P[List[String]] =
     sym("(") ~> sepBy0(formalParam, sym(",")) <~ sym(")")
+
+  private lazy val bareParams: P[List[String]] =
+    sepBy1(formalParam, sym(","))
 
   private lazy val defReceiverName: P[String] =
     constPathSegments.map(_.mkString("::")) /
@@ -634,7 +796,7 @@ object RubySubsetParser {
       methodIdentifier
 
   private lazy val simpleStatement: P[Statement] =
-    ((returnStmt / retryStmt / logicalAssignStmt / compoundAssignStmt / assignStmt / blockCallStmt / receiverCommandCall.map(ExprStmt(_)) / commandCall.map(ExprStmt(_)) / refer(expr).map(ExprStmt(_))) ~ modifierSuffix.?).map {
+    ((returnStmt / retryStmt / logicalAssignStmt / compoundAssignStmt / constAssignStmt / multiAssignStmt / assignStmt / chainedCommandCall.map(ExprStmt(_)) / receiverCommandCall.map(ExprStmt(_)) / commandCall.map(ExprStmt(_)) / refer(expr).map(ExprStmt(_))) ~ (inlineSpacing ~> modifierSuffix).?).map {
       case stmt ~ Some(modifier) => modifier(stmt)
       case stmt ~ None => stmt
     }
@@ -693,9 +855,23 @@ object RubySubsetParser {
     }
 
   private lazy val defStmt: P[Statement] =
-    (kw("def") ~ defName ~ params.? ~ statementSep.* ~ blockStatements ~ statementSep.* ~ kw("end")).map {
-      case _ ~ name ~ maybeParams ~ _ ~ body ~ _ ~ _ =>
-        Def(name, maybeParams.getOrElse(Nil), body)
+    (
+      kw("def") ~
+      defName ~
+      (params / bareParams).? ~
+      statementSep.* ~
+      blockStatementsUntil(kw("ensure") / kw("end")) ~
+      statementSep.* ~
+      (kw("ensure") ~ statementSep.* ~ blockStatementsUntil(kw("end"))).? ~
+      statementSep.* ~
+      kw("end")
+    ).map {
+      case _ ~ name ~ maybeParams ~ _ ~ body ~ _ ~ ensureOpt ~ _ ~ _ =>
+        val statements = ensureOpt match {
+          case Some(_ ~ _ ~ ensureBody) => List(BeginRescue(body, Nil, Nil, ensureBody))
+          case None => body
+        }
+        Def(name, maybeParams.getOrElse(Nil), statements)
     }
 
   private lazy val singletonClassStmt: P[Statement] =
@@ -808,8 +984,8 @@ object RubySubsetParser {
       case c => c.toString
     } + "\""
 
-  private def normalizeSquigglyHeredoc(input: String): String = {
-    val heredocPattern = "<<~([A-Za-z_][A-Za-z0-9_]*)".r
+  private def normalizeHeredoc(input: String): String = {
+    val heredocPattern = raw"(?<![\w\)\]\}])<<([~-]?)([A-Za-z_][A-Za-z0-9_]*)".r
     val outputLines = scala.collection.mutable.ArrayBuffer.empty[String]
     val replacements = scala.collection.mutable.ArrayBuffer.empty[(String, String)]
     val pending = scala.collection.mutable.Queue.empty[PendingHeredoc]
@@ -819,7 +995,10 @@ object RubySubsetParser {
     lines.foreach { line =>
       if(pending.nonEmpty) {
         val current = pending.front
-        if(line.trim == current.terminator) {
+        val isTerminator =
+          if(current.allowIndentedTerminator) line.trim == current.terminator
+          else line == current.terminator
+        if(isTerminator) {
           pending.dequeue()
           val content =
             if(current.lines.isEmpty) ""
@@ -836,7 +1015,12 @@ object RubySubsetParser {
           val tokens = matches.map { m =>
             val token = s"__MACROPEG_HEREDOC_${nextId}__"
             nextId += 1
-            pending.enqueue(PendingHeredoc(token, m.group(1), scala.collection.mutable.ArrayBuffer.empty[String]))
+            val marker = m.group(1)
+            val terminator = m.group(2)
+            val allowIndented = marker == "-" || marker == "~"
+            pending.enqueue(
+              PendingHeredoc(token, terminator, allowIndented, scala.collection.mutable.ArrayBuffer.empty[String])
+            )
             token
           }
           val replacedLine = (matches zip tokens).reverse.foldLeft(line) { case (acc, (m, token)) =>
@@ -864,7 +1048,7 @@ object RubySubsetParser {
   }
 
   def parse(input: String): Either[String, Program] = {
-    val normalized = normalizeSquigglyHeredoc(stripXOptionPreamble(input))
+    val normalized = normalizeHeredoc(stripXOptionPreamble(input))
     parseAll(program, normalized).left.map(f => formatFailure(normalized, f))
   }
 }

--- a/src/main/scala/com/github/kmizu/macro_peg/ruby/RubySubsetParser.scala
+++ b/src/main/scala/com/github/kmizu/macro_peg/ruby/RubySubsetParser.scala
@@ -2,6 +2,7 @@ package com.github.kmizu.macro_peg.ruby
 
 import com.github.kmizu.macro_peg.combinator.MacroParsers._
 import com.github.kmizu.macro_peg.ruby.RubyAst._
+import scala.util.Try
 
 object RubySubsetParser {
   private type P[+A] = MacroParser[A]
@@ -40,10 +41,13 @@ object RubySubsetParser {
     (parser ~ inlineSpacing).map(_._1)
 
   private def kw(name: String): P[String] =
-    token(string(name)).label(s"`$name`")
+    token(string(name) <~ !identCont).label(s"`$name`")
 
   private def sym(name: String): P[String] =
     token(string(name))
+
+  private lazy val labelColon: P[String] =
+    token(":".s <~ !":".s)
 
   private lazy val identStart: P[String] =
     range('a' to 'z', 'A' to 'Z', '_' to '_')
@@ -161,17 +165,60 @@ object RubySubsetParser {
     )
 
   private lazy val constPathSegments: P[List[String]] =
-    (constName ~ (sym("::") ~ constName).*).map {
-      case head ~ tail => head :: tail.map(_._2)
+    (sym("::").? ~ constName ~ (sym("::") ~ constName).*).map {
+      case _ ~ head ~ tail => head :: tail.map(_._2)
     }
 
+  private def digitsWithUnderscore(digit: P[String]): P[String] =
+    (digit.+ ~ ("_".s ~ digit.+).*).map {
+      case head ~ tail =>
+        head.mkString + tail.map { case _ ~ ds => "_" + ds.mkString }.mkString
+    }
+
+  private lazy val decimalDigitsRaw: P[String] =
+    digitsWithUnderscore(range('0' to '9'))
+
+  private lazy val binaryDigitsRaw: P[String] =
+    digitsWithUnderscore(range('0' to '1'))
+
+  private lazy val octalDigitsRaw: P[String] =
+    digitsWithUnderscore(range('0' to '7'))
+
+  private lazy val hexDigitsRaw: P[String] =
+    digitsWithUnderscore(range('0' to '9', 'a' to 'f', 'A' to 'F'))
+
+  private lazy val integerLiteralRaw: P[(String, Int)] =
+    ("0".s ~ ("b".s / "B".s) ~ binaryDigitsRaw).map { case _ ~ _ ~ ds => ds -> 2 } /
+      ("0".s ~ ("o".s / "O".s) ~ octalDigitsRaw).map { case _ ~ _ ~ ds => ds -> 8 } /
+      ("0".s ~ ("d".s / "D".s) ~ decimalDigitsRaw).map { case _ ~ _ ~ ds => ds -> 10 } /
+      ("0".s ~ ("x".s / "X".s) ~ hexDigitsRaw).map { case _ ~ _ ~ ds => ds -> 16 } /
+      decimalDigitsRaw.map(_ -> 10)
+
   private lazy val integerLiteral: P[Expr] =
-    token((range('0' to '9').+ <~ !(".".s ~ range('0' to '9')))).map(ds => IntLiteral(ds.mkString.toLong))
+    token((integerLiteralRaw <~ !(".".s ~ range('0' to '9')) <~ !identCont)).map {
+      case (raw, base) =>
+        IntLiteral(BigInt(raw.replace("_", ""), base))
+    }
+
+  private lazy val floatExponentRaw: P[String] =
+    (range('e' to 'e', 'E' to 'E') ~ ("+".s / "-".s).? ~ range('0' to '9').+).map {
+      case e ~ signOpt ~ digits =>
+        e + signOpt.getOrElse("") + digits.mkString
+    }
+
+  private lazy val floatLiteralRaw: P[String] =
+    (decimalDigitsRaw ~ ".".s ~ decimalDigitsRaw ~ floatExponentRaw.?).map {
+      case intPart ~ _ ~ fracPart ~ exp =>
+        intPart + "." + fracPart + exp.getOrElse("")
+    } /
+      (decimalDigitsRaw ~ floatExponentRaw).map {
+        case intPart ~ exp => intPart + exp
+      }
 
   private lazy val floatLiteral: P[Expr] =
-    token((range('0' to '9').+ ~ ".".s ~ range('0' to '9').+)).map {
-      case intPart ~ _ ~ fracPart =>
-        FloatLiteral(s"${intPart.mkString}.${fracPart.mkString}".toDouble)
+    token((floatLiteralRaw <~ !identCont)).map { raw =>
+      val normalized = raw.replace("_", "")
+      FloatLiteral(Try(normalized.toDouble).getOrElse(Double.NaN))
     }
 
   private lazy val escapedChar: P[String] =
@@ -280,6 +327,18 @@ object RubySubsetParser {
         ArrayLiteral(words)
     })
 
+  private def percentSymbolArrayLiteral(open: String, close: String): P[Expr] =
+    token((("%i".s / "%I".s) ~ percentBody(open, close)).map {
+      case _ ~ body =>
+        val symbols =
+          body
+            .split("\\s+")
+            .toList
+            .filter(_.nonEmpty)
+            .map(value => SymbolLiteral(value, UnknownSpan))
+        ArrayLiteral(symbols)
+    })
+
   private lazy val percentQuotedStringLiteral: P[Expr] =
     percentStringLiteral("{", "}") /
       percentStringLiteral("(", ")") /
@@ -291,6 +350,12 @@ object RubySubsetParser {
       percentWordArrayLiteral("(", ")") /
       percentWordArrayLiteral("[", "]") /
       percentWordArrayLiteral("<", ">")
+
+  private lazy val percentSymbolArray: P[Expr] =
+    percentSymbolArrayLiteral("{", "}") /
+      percentSymbolArrayLiteral("(", ")") /
+      percentSymbolArrayLiteral("[", "]") /
+      percentSymbolArrayLiteral("<", ">")
 
   private def percentRegexLiteral(open: String, close: String): P[Expr] =
     token(("%r".s ~ percentBody(open, close) ~ range('a' to 'z', 'A' to 'Z').*).map {
@@ -323,16 +388,39 @@ object RubySubsetParser {
         case _ ~ chars ~ _ ~ _ => StringLiteral(chars.mkString)
       })
 
+  private lazy val symbolOperatorNameNoSpace: P[String] =
+    "===".s /
+      "<=>".s /
+      "!=".s /
+      "==".s /
+      "<=".s /
+      ">=".s /
+      "<<".s /
+      ">>".s /
+      "[]=".s /
+      "[]".s /
+      "<".s /
+      ">".s /
+      "+".s /
+      "-".s /
+      "*".s /
+      "/".s /
+      "%".s /
+      "&".s /
+      "|".s /
+      "^".s /
+      "~".s
+
   private lazy val symbolLiteral: P[Expr] =
     (sym(":") ~ token("**".s / "*".s / "&".s)).map { case _ ~ name => SymbolLiteral(name, UnknownSpan) } /
-      (sym(":") ~ token(identifierRaw)).map { case _ ~ name => SymbolLiteral(name, UnknownSpan) } /
+      (sym(":") ~ token(symbolOperatorNameNoSpace / methodIdentifierRaw)).map { case _ ~ name => SymbolLiteral(name, UnknownSpan) } /
       (sym(":") ~ classVarName).map { case _ ~ name => SymbolLiteral(name, UnknownSpan) }
       /
       (sym(":") ~ instanceVarName).map { case _ ~ name => SymbolLiteral(name, UnknownSpan) }
       /
       (sym(":") ~ globalVarName).map { case _ ~ name => SymbolLiteral(name, UnknownSpan) }
       /
-      (sym(":") ~ token(("\"".s ~ (escapedChar / plainStringChar).* ~ "\"".s).map {
+      (sym(":") ~ token(("\"".s ~ (escapedChar / interpolationSegment / plainStringChar).* ~ "\"".s).map {
         case _ ~ chars ~ _ => chars.mkString
       })).map { case _ ~ name => SymbolLiteral(name, UnknownSpan) }
 
@@ -371,10 +459,12 @@ object RubySubsetParser {
     spacing ~> refer(expr) <~ spacing
 
   private lazy val arrayLiteral: P[Expr] =
-    (sym("[") ~> spacing ~> sepBy0(spacedExpr, sym(",")) <~ spacing <~ sym("]")).map(ArrayLiteral(_))
+    (sym("[") ~> spacing ~> sepBy0(spacedExpr, sym(",")) ~ ((sym(",") <~ spacing).?) <~ spacing <~ sym("]")).map {
+      case values ~ _ => ArrayLiteral(values)
+    }
 
   private lazy val labelHashEntry: P[(Expr, Expr)] =
-    ((identifierNoSpace <~ sym(":")) ~ refer(expr)).map {
+    ((identifierNoSpace <~ labelColon) ~ refer(expr)).map {
       case name ~ value => SymbolLiteral(name, UnknownSpan) -> value
     }
 
@@ -383,13 +473,22 @@ object RubySubsetParser {
       (refer(expr) ~ sym("=>") ~ refer(expr)).map { case key ~ _ ~ value => key -> value }
 
   private lazy val hashLiteral: P[Expr] =
-    (sym("{") ~> spacing ~> sepBy0(spacing ~> hashEntry <~ spacing, sym(",")) <~ spacing <~ sym("}")).map(HashLiteral(_))
+    (sym("{") ~> spacing ~> sepBy0(spacing ~> hashEntry <~ spacing, sym(",")) ~ ((sym(",") <~ spacing).?) <~ spacing <~ sym("}")).map {
+      case entries ~ _ => HashLiteral(entries)
+    }
 
   private lazy val callArgs: P[List[Expr]] =
-    sym("(") ~> spacing ~> sepBy0(spacing ~> callArgExpr <~ spacing, sym(",")) <~ spacing <~ sym(")")
+    (sym("(") ~> spacing ~> sepBy0(spacing ~> callArgExpr <~ spacing, sym(",")) ~ ((sym(",") <~ spacing).?) <~ spacing <~ sym(")")).map {
+      case args ~ _ => args
+    }
+
+  private lazy val commandArgSep: P[Unit] =
+    (inlineSpacing ~> sym(",") <~ spacing).void
 
   private lazy val commandArgs: P[List[Expr]] =
-    sepBy1(callArgExpr, sym(","))
+    (callArgExpr ~ (commandArgSep ~> callArgExpr).* ~ (inlineSpacing ~> sym(",")).?).map {
+      case first ~ rest ~ _ => first :: rest
+    }
 
   private lazy val blockPassArgExpr: P[Expr] =
     (sym("&") ~ identifier).map { case _ ~ name => LocalVar(s"&$name") } /
@@ -402,13 +501,21 @@ object RubySubsetParser {
     (sym("*") ~ refer(expr)).map(_._2)
 
   private lazy val keywordArgExpr: P[Expr] =
-    ((identifierNoSpace <~ sym(":")) ~ refer(expr)).map {
+    ((identifierNoSpace <~ labelColon) ~ refer(expr)).map {
       case name ~ value =>
         HashLiteral(List(SymbolLiteral(name, UnknownSpan) -> value))
     }
 
+  private lazy val hashRocketArgKeyExpr: P[Expr] =
+    symbolLiteral / stringLiteral / variable / constRef
+
+  private lazy val hashRocketArgExpr: P[Expr] =
+    (((hashRocketArgKeyExpr <~ sym("=>").and).and ~> hashRocketArgKeyExpr) ~ sym("=>") ~ refer(expr)).map {
+      case key ~ _ ~ value => HashLiteral(List(key -> value))
+    }
+
   private lazy val callArgExpr: P[Expr] =
-    blockPassArgExpr / doubleSplatArgExpr / splatArgExpr / keywordArgExpr / refer(expr)
+    blockPassArgExpr / doubleSplatArgExpr / splatArgExpr / keywordArgExpr / hashRocketArgExpr / refer(expr)
 
   private lazy val functionCall: P[Expr] =
     (methodIdentifier ~ callArgs).map { case name ~ args => Call(None, name, args) }
@@ -459,6 +566,7 @@ object RubySubsetParser {
       backtickLiteral /
       percentQuotedStringLiteral /
       percentWordArray /
+      percentSymbolArray /
       regexLiteral /
       symbolLiteral /
       boolLiteral /
@@ -480,7 +588,7 @@ object RubySubsetParser {
     (identifier ~ (sym("=") ~ refer(expr)).?).map(_._1)
 
   private lazy val keywordParam: P[String] =
-    ((identifierNoSpace <~ sym(":")) ~ refer(expr).?).map {
+    ((identifierNoSpace <~ labelColon) ~ refer(expr).?).map {
       case name ~ _ => s"$name:"
     }
 
@@ -491,8 +599,13 @@ object RubySubsetParser {
       keywordParam /
       positionalParam
 
+  private lazy val destructuredBlockParam: P[String] =
+    (sym("(") ~> sepBy0(formalParam, sym(",")) <~ sym(")")).map { parts =>
+      s"(${parts.mkString(",")})"
+    }
+
   private lazy val blockParams: P[List[String]] =
-    sym("|") ~> sepBy0(formalParam, sym(",")) <~ sym("|")
+    sym("|") ~> sepBy0(destructuredBlockParam / formalParam, sym(",")) <~ sym("|")
 
   private lazy val doBlock: P[Block] =
     (
@@ -548,13 +661,17 @@ object RubySubsetParser {
     }
 
   private lazy val operatorMethodName: P[String] =
+    "**".s /
     "<<".s /
       ">>".s /
       "*".s /
       "+".s /
       "-".s /
       "/".s /
-      "%".s
+      "%".s /
+      "|".s /
+      "&".s /
+      "^".s
 
   private lazy val suffixMethodName: P[String] =
     receiverMethodNameNoSpace / operatorMethodName
@@ -612,6 +729,12 @@ object RubySubsetParser {
   private def infixLogicalKeyword(op: String): P[(Expr, Expr) => Expr] =
     ((op.s <~ !identCont) <~ spacing).map(_ => (lhs: Expr, rhs: Expr) => BinaryOp(lhs, op, rhs))
 
+  private lazy val powerExpr: P[Expr] =
+    (postfixExpr ~ (sym("**") ~> refer(powerExpr)).?).map {
+      case base ~ Some(exp) => BinaryOp(base, "**", exp)
+      case base ~ None => base
+    }
+
   private lazy val unaryExpr: P[Expr] =
     (kw("not") ~ refer(unaryExpr)).map {
       case _ ~ target => UnaryOp("not", target)
@@ -619,13 +742,16 @@ object RubySubsetParser {
     (sym("!") ~ refer(unaryExpr)).map {
       case _ ~ target => UnaryOp("!", target)
     } /
+      (sym("~") ~ refer(unaryExpr)).map {
+        case _ ~ target => UnaryOp("~", target)
+      } /
       (sym("-") ~ refer(unaryExpr)).map {
         case _ ~ target => UnaryOp("-", target)
       } /
       (sym("+") ~ refer(unaryExpr)).map {
         case _ ~ target => UnaryOp("+", target)
       } /
-      (postfixExpr <~ horizontalSpacing)
+      (powerExpr <~ horizontalSpacing)
 
   private lazy val mulDivExpr: P[Expr] =
     chainl(unaryExpr)(infix("*") / infix("/") / infix("%"))
@@ -636,11 +762,17 @@ object RubySubsetParser {
   private lazy val shiftExpr: P[Expr] =
     chainl(addSubExpr)(infix("<<") / infix(">>"))
 
+  private lazy val bitAndExpr: P[Expr] =
+    chainl(shiftExpr)(infix("&"))
+
+  private lazy val bitOrExpr: P[Expr] =
+    chainl(bitAndExpr)(infix("|") / infix("^"))
+
   private lazy val relationalExpr: P[Expr] =
-    chainl(shiftExpr)(infix("<=") / infix(">=") / infix("<") / infix(">"))
+    chainl(bitOrExpr)(infix("<=") / infix(">=") / infix("<") / infix(">"))
 
   private lazy val equalityExpr: P[Expr] =
-    chainl(relationalExpr)(infix("==") / infix("!=") / infix("=~") / infix("!~"))
+    chainl(relationalExpr)(infix("==") / infix("===") / infix("!=") / infix("<=>") / infix("=~") / infix("!~"))
 
   private lazy val rangeExpr: P[Expr] =
     (equalityExpr ~ ((sym("..") / sym("...")) ~ equalityExpr).?).map {
@@ -832,8 +964,6 @@ object RubySubsetParser {
       multiAssignStmt /
       assignStmt /
       chainedCommandCall.map(ExprStmt(_)) /
-      receiverCommandCall.map(ExprStmt(_)) /
-      commandCall.map(ExprStmt(_)) /
       refer(expr).map(ExprStmt(_))
 
   private lazy val statementBase: P[Statement] =
@@ -1058,7 +1188,7 @@ object RubySubsetParser {
     } + "\""
 
   private def normalizeHeredoc(input: String): String = {
-    val heredocPattern = raw"(?<![\w\)\]\}])<<([~-]?)([A-Za-z_][A-Za-z0-9_]*)".r
+    val heredocPattern = raw"""(?<![\w\)\]\}])<<([~-]?)(?:'([^'\n]+)'|"([^"\n]+)"|`([^`\n]+)`|([A-Za-z_][A-Za-z0-9_]*))""".r
     val outputLines = scala.collection.mutable.ArrayBuffer.empty[String]
     val replacements = scala.collection.mutable.ArrayBuffer.empty[(String, String)]
     val pending = scala.collection.mutable.Queue.empty[PendingHeredoc]
@@ -1089,7 +1219,12 @@ object RubySubsetParser {
             val token = s"__MACROPEG_HEREDOC_${nextId}__"
             nextId += 1
             val marker = m.group(1)
-            val terminator = m.group(2)
+            val terminator =
+              Option(m.group(2))
+                .orElse(Option(m.group(3)))
+                .orElse(Option(m.group(4)))
+                .orElse(Option(m.group(5)))
+                .getOrElse("")
             val allowIndented = marker == "-" || marker == "~"
             pending.enqueue(
               PendingHeredoc(token, terminator, allowIndented, scala.collection.mutable.ArrayBuffer.empty[String])

--- a/src/test/scala/com/github/kmizu/macro_peg/MacroParsersAdvancedSpec.scala
+++ b/src/test/scala/com/github/kmizu/macro_peg/MacroParsersAdvancedSpec.scala
@@ -52,5 +52,52 @@ class MacroParsersAdvancedSpec extends AnyFunSpec with Diagrams {
           fail(s"unexpected parse result: $other")
       }
     }
+
+    it("detects direct non-consuming recursion with guard") {
+      object G {
+        lazy val A: P[String] = guard("A")(refer(A))
+      }
+      val failure = G.A("").asInstanceOf[ParseFailure]
+      assert(failure.message.contains("infinite recursion detected"))
+    }
+
+    it("detects indirect non-consuming recursion with guard") {
+      object G {
+        lazy val A: P[String] = guard("A")(refer(B))
+        lazy val B: P[String] = guard("B")(refer(A))
+      }
+      val failure = G.A("").asInstanceOf[ParseFailure]
+      assert(failure.message.contains("infinite recursion detected"))
+    }
+
+    it("detects direct non-consuming recursion via refer without explicit guard") {
+      object G {
+        lazy val A: P[String] = refer(A)
+      }
+      val failure = G.A("").asInstanceOf[ParseFailure]
+      assert(failure.message.contains("infinite recursion detected"))
+    }
+
+    it("detects indirect non-consuming recursion via refer without explicit guard") {
+      object G {
+        lazy val A: P[String] = refer(B)
+        lazy val B: P[String] = refer(A)
+      }
+      val failure = G.A("").asInstanceOf[ParseFailure]
+      assert(failure.message.contains("infinite recursion detected"))
+    }
+
+    it("memoizes repeated parser invocation at the same input position") {
+      var calls = 0
+      val base =
+        ("".s.map { _ =>
+          calls += 1
+          ()
+        } ~ !any).map(_ => ())
+      val memoized = base.memo
+      val parser = memoized / memoized
+      parseAll(parser, "x")
+      assert(calls == 1)
+    }
   }
 }

--- a/src/test/scala/com/github/kmizu/macro_peg/ruby/RubySubsetParserSpec.scala
+++ b/src/test/scala/com/github/kmizu/macro_peg/ruby/RubySubsetParserSpec.scala
@@ -53,6 +53,23 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
       )
     }
 
+    it("parses def parameters without parentheses") {
+      val input = "def add as; as; end"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          Def(
+            "add",
+            List("as"),
+            List(ExprStmt(LocalVar("as", UnknownSpan), UnknownSpan)),
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
     it("parses array and hash literals") {
       val input = "x = [1, 2, {\"a\" => 3}]"
       val parsed = RubySubsetParser.parse(input)
@@ -266,6 +283,12 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
       )
     }
 
+    it("parses brace block with trailing space before close") {
+      val input = "err_reader = Thread.new{ r.read }"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+    }
+
     it("parses newline-separated statements") {
       val input =
         """x = 1
@@ -385,6 +408,12 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
       )
     }
 
+    it("parses command call arg with spaced brace-block chain") {
+      val input = "puts tests.map {|path| File.basename(path) }.inspect"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+    }
+
     it("parses safe-navigation call with operator method name") {
       val input = "x = timeout&.*(timeout_scale)"
       val parsed = RubySubsetParser.parse(input)
@@ -449,6 +478,31 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
           ),
           ExprStmt(
             Call(Some(SelfExpr(UnknownSpan)), "log", List(IntLiteral(1)), UnknownSpan),
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
+    it("parses keyword-named receiver method and chained command args") {
+      val input = "x = self.class; self.class.add self"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          Assign(
+            "x",
+            Call(Some(SelfExpr(UnknownSpan)), "class", Nil, UnknownSpan),
+            UnknownSpan
+          ),
+          ExprStmt(
+            Call(
+              Some(Call(Some(SelfExpr(UnknownSpan)), "class", Nil, UnknownSpan)),
+              "add",
+              List(SelfExpr(UnknownSpan)),
+              UnknownSpan
+            ),
             UnknownSpan
           )
         ), UnknownSpan)
@@ -575,6 +629,72 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
       )
     }
 
+    it("parses do-end block with bare ensure section") {
+      val input =
+        """Thread.new do
+          |  work
+          |ensure
+          |  cleanup
+          |end""".stripMargin
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          ExprStmt(
+            CallWithBlock(
+              Call(Some(ConstRef(List("Thread"), UnknownSpan)), "new", Nil, UnknownSpan),
+              Block(
+                Nil,
+                List(
+                  BeginRescue(
+                    List(ExprStmt(LocalVar("work", UnknownSpan), UnknownSpan)),
+                    Nil,
+                    Nil,
+                    List(ExprStmt(LocalVar("cleanup", UnknownSpan), UnknownSpan)),
+                    UnknownSpan
+                  )
+                ),
+                UnknownSpan
+              ),
+              UnknownSpan
+            ),
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
+    it("parses def body with bare ensure section") {
+      val input =
+        """def f
+          |  x = 1
+          |ensure
+          |  x = 2
+          |end""".stripMargin
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          Def(
+            "f",
+            Nil,
+            List(
+              BeginRescue(
+                List(Assign("x", IntLiteral(1, UnknownSpan), UnknownSpan)),
+                Nil,
+                Nil,
+                List(Assign("x", IntLiteral(2, UnknownSpan), UnknownSpan)),
+                UnknownSpan
+              )
+            ),
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
     it("parses singleton class definition") {
       val input =
         """class << self
@@ -613,6 +733,22 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
           Assign("$z", IntLiteral(3), UnknownSpan),
           Assign("w", BinaryOp(InstanceVar("@x", UnknownSpan), "+", ClassVar("@@y", UnknownSpan), UnknownSpan), UnknownSpan),
           Assign("v", GlobalVar("$z", UnknownSpan), UnknownSpan)
+        ), UnknownSpan)
+      )
+    }
+
+    it("parses multiple assignment from expression") {
+      val input = "faildesc, t = super"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          MultiAssign(
+            List("faildesc", "t"),
+            LocalVar("super", UnknownSpan),
+            UnknownSpan
+          )
         ), UnknownSpan)
       )
     }
@@ -731,6 +867,53 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
       )
     }
 
+    it("parses splat and keyword-splat params and call args") {
+      val input = "def f(*args, **opts, &block); g(*args, **opts, &block); end"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          Def(
+            "f",
+            List("*args", "**opts", "&block"),
+            List(
+              ExprStmt(
+                Call(
+                  None,
+                  "g",
+                  List(LocalVar("args", UnknownSpan), LocalVar("opts", UnknownSpan), LocalVar("&block", UnknownSpan)),
+                  UnknownSpan
+                ),
+                UnknownSpan
+              )
+            ),
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
+    it("parses symbol block-pass argument") {
+      val input = "ts.each(&:kill)"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          ExprStmt(
+            Call(
+              Some(LocalVar("ts", UnknownSpan)),
+              "each",
+              List(SymbolLiteral("kill", UnknownSpan)),
+              UnknownSpan
+            ),
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
     it("parses method names with punctuation and unary/binary operators") {
       val input = "if !Dir.respond_to?(:mktmpdir) || force; ok! 1; end"
       val parsed = RubySubsetParser.parse(input)
@@ -794,6 +977,40 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
       )
     }
 
+    it("parses constant receiver assignment with postfix if modifier") {
+      val input = "BT.tty = $stderr.tty? if BT.tty.nil?"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          IfExpr(
+            Call(
+              Some(Call(Some(ConstRef(List("BT"), UnknownSpan)), "tty", Nil, UnknownSpan)),
+              "nil?",
+              Nil,
+              UnknownSpan
+            ),
+            List(
+              ExprStmt(
+                Call(
+                  Some(ConstRef(List("BT"), UnknownSpan)),
+                  "tty=",
+                  List(
+                    Call(Some(GlobalVar("$stderr", UnknownSpan)), "tty?", Nil, UnknownSpan)
+                  ),
+                  UnknownSpan
+                ),
+                UnknownSpan
+              )
+            ),
+            Nil,
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
     it("parses receiver logical assignment inside condition") {
       val input = "if (self.columns ||= 0) < n; :ok; end"
       val parsed = RubySubsetParser.parse(input)
@@ -815,6 +1032,34 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
             ),
             List(ExprStmt(SymbolLiteral("ok", UnknownSpan), UnknownSpan)),
             Nil,
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
+    it("parses index logical assignment expression") {
+      val input = "colors[n] ||= c"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          ExprStmt(
+            Call(
+              Some(LocalVar("colors", UnknownSpan)),
+              "[]=",
+              List(
+                LocalVar("n", UnknownSpan),
+                BinaryOp(
+                  Call(Some(LocalVar("colors", UnknownSpan)), "[]", List(LocalVar("n", UnknownSpan)), UnknownSpan),
+                  "||",
+                  LocalVar("c", UnknownSpan),
+                  UnknownSpan
+                )
+              ),
+              UnknownSpan
+            ),
             UnknownSpan
           )
         ), UnknownSpan)
@@ -892,6 +1137,12 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
       )
     }
 
+    it("parses receiver logical assignment with regex-match ternary") {
+      val input = """BT.wn ||= /-j(\d+)?/ =~ (ENV["MAKEFLAGS"] || ENV["MFLAGS"]) ? $1.to_i : 1"""
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+    }
+
     it("parses def name ending with question mark") {
       val input = "def empty?; true; end"
       val parsed = RubySubsetParser.parse(input)
@@ -925,6 +1176,39 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
         ast == Program(List(
           ExprStmt(
             Call(None, "assert_match", List(StringLiteral("\\\\Aok\\\\z"), LocalVar("value", UnknownSpan)), UnknownSpan),
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
+    it("parses interpolated double-quoted strings with nested quotes") {
+      val input = """x = "\e[;#{colors["pass"] || "32"}m""""
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          Assign("x", StringLiteral("""e[;#{colors["pass"] || "32"}m""", UnknownSpan), UnknownSpan)
+        ), UnknownSpan)
+      )
+    }
+
+    it("parses backtick command literals with call chaining") {
+      val input = "target_version = `#{BT.ruby} -v`.chomp"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          Assign(
+            "target_version",
+            Call(
+              Some(StringLiteral("#{BT.ruby} -v", UnknownSpan)),
+              "chomp",
+              Nil,
+              UnknownSpan
+            ),
             UnknownSpan
           )
         ), UnknownSpan)
@@ -1086,6 +1370,34 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
       )
     }
 
+    it("parses multiline hash entries with nested hash values") {
+      val input =
+        """payload = {
+          |  testPath: path,
+          |  data: {
+          |    lineNumber: self.lineno
+          |  }
+          |}
+          |""".stripMargin
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          Assign(
+            "payload",
+            HashLiteral(List(
+              SymbolLiteral("testPath", UnknownSpan) -> LocalVar("path", UnknownSpan),
+              SymbolLiteral("data", UnknownSpan) -> HashLiteral(List(
+                SymbolLiteral("lineNumber", UnknownSpan) -> Call(Some(SelfExpr(UnknownSpan)), "lineno", Nil, UnknownSpan)
+              ), UnknownSpan)
+            ), UnknownSpan),
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
     it("parses call arguments with keyword labels") {
       val input = """Prism.parse("1", command_line: "p", line: 4)"""
       val parsed = RubySubsetParser.parse(input)
@@ -1139,6 +1451,25 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
       )
     }
 
+    it("parses dash heredoc arguments") {
+      val input =
+        """puts(<<-End)
+          |hello
+          |End
+          |""".stripMargin
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          ExprStmt(
+            Call(None, "puts", List(StringLiteral("hello\n", UnknownSpan)), UnknownSpan),
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
     it("parses unary plus and minus operators") {
       val input = "line = -2; value = +line"
       val parsed = RubySubsetParser.parse(input)
@@ -1179,6 +1510,32 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
       )
     }
 
+    it("parses unary not keyword in logical expressions") {
+      val input = "if tests and not ARGV.empty?; :ok; end"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          IfExpr(
+            BinaryOp(
+              LocalVar("tests", UnknownSpan),
+              "and",
+              UnaryOp(
+                "not",
+                Call(Some(ConstRef(List("ARGV"), UnknownSpan)), "empty?", Nil, UnknownSpan),
+                UnknownSpan
+              ),
+              UnknownSpan
+            ),
+            List(ExprStmt(SymbolLiteral("ok", UnknownSpan), UnknownSpan)),
+            Nil,
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
     it("parses while with assignment expression condition") {
       val input = "while (node = queue.shift); return node if node; end"
       val parsed = RubySubsetParser.parse(input)
@@ -1199,6 +1556,26 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
                 Nil,
                 UnknownSpan
               )
+            ),
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
+    it("parses compound assignment in expression context") {
+      val input = "x = (@count += 1)"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          Assign(
+            "x",
+            AssignExpr(
+              "@count",
+              BinaryOp(InstanceVar("@count", UnknownSpan), "+", IntLiteral(1, UnknownSpan), UnknownSpan),
+              UnknownSpan
             ),
             UnknownSpan
           )
@@ -1319,6 +1696,67 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
           )
         ), UnknownSpan)
       )
+    }
+
+    it("parses constant assignment with call-chain and do block") {
+      val input = "BT = Class.new(bt) do; end.new"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          Assign(
+            "BT",
+            Call(
+              Some(
+                CallWithBlock(
+                  Call(Some(ConstRef(List("Class"), UnknownSpan)), "new", List(LocalVar("bt", UnknownSpan)), UnknownSpan),
+                  Block(Nil, Nil, UnknownSpan),
+                  UnknownSpan
+                )
+              ),
+              "new",
+              Nil,
+              UnknownSpan
+            ),
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
+    it("parses constant assignment with multiline do-end block") {
+      val input =
+        """BT = Class.new(bt) do
+          |  def indent=(n)
+          |    super
+          |  end
+          |end
+          |""".stripMargin
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+    }
+
+    it("parses and-chain condition with constant receiver comparisons") {
+      val input =
+        """if e and BT.columns > 0 and BT.tty and !BT.verbose
+          |  ""
+          |end
+          |""".stripMargin
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+    }
+
+    it("parses comparison on constant receiver call") {
+      val input = "BT.columns > 0"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+    }
+
+    it("parses logical and with constant receiver comparison") {
+      val input = "e and BT.columns > 0"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
     }
 
     it("parses case when else expression") {

--- a/src/test/scala/com/github/kmizu/macro_peg/ruby/RubySubsetParserSpec.scala
+++ b/src/test/scala/com/github/kmizu/macro_peg/ruby/RubySubsetParserSpec.scala
@@ -262,6 +262,24 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
       )
     }
 
+    it("parses command-style call args split across newlines") {
+      val input =
+        """assert_equal "a",
+          |             "b"
+          |""".stripMargin
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          ExprStmt(
+            Call(None, "assert_equal", List(StringLiteral("a", UnknownSpan), StringLiteral("b", UnknownSpan)), UnknownSpan),
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
     it("parses command-style call with postfix modifier") {
       val input = "log 1, 2 if ready"
       val parsed = RubySubsetParser.parse(input)
@@ -313,6 +331,29 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
       )
     }
 
+    it("parses destructured block parameters") {
+      val input = "tests.each do |(insn, expr, *a)| insn; end"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          ExprStmt(
+            CallWithBlock(
+              Call(Some(LocalVar("tests", UnknownSpan)), "each", Nil, UnknownSpan),
+              Block(
+                List("(insn,expr,*a)"),
+                List(ExprStmt(LocalVar("insn", UnknownSpan), UnknownSpan)),
+                UnknownSpan
+              ),
+              UnknownSpan
+            ),
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
     it("parses do-end block attached to call") {
       val input = "items.each do |x| puts x; end"
       val parsed = RubySubsetParser.parse(input)
@@ -334,6 +375,16 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
           )
         ), UnknownSpan)
       )
+    }
+
+    it("does not confuse keyword prefixes in identifiers inside do-blocks") {
+      val input =
+        """items.each do |item|
+          |  define_method("x")
+          |end
+          |""".stripMargin
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
     }
 
     it("parses brace block attached to call") {
@@ -609,6 +660,18 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
 
     it("parses constant path expressions") {
       val input = "x = JSON::Parser"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          Assign("x", ConstRef(List("JSON", "Parser"), UnknownSpan), UnknownSpan)
+        ), UnknownSpan)
+      )
+    }
+
+    it("parses top-level constant path expressions") {
+      val input = "x = ::JSON::Parser"
       val parsed = RubySubsetParser.parse(input)
       assert(parsed.isRight)
       val ast = parsed.toOption.get
@@ -1502,6 +1565,47 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
       )
     }
 
+    it("parses symbol literals with method suffix and operator names") {
+      val input = "assert_operator(x, :!=, y); assert_predicate(value, :frozen?)"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          ExprStmt(
+            Call(
+              None,
+              "assert_operator",
+              List(LocalVar("x", UnknownSpan), SymbolLiteral("!=", UnknownSpan), LocalVar("y", UnknownSpan)),
+              UnknownSpan
+            ),
+            UnknownSpan
+          ),
+          ExprStmt(
+            Call(
+              None,
+              "assert_predicate",
+              List(LocalVar("value", UnknownSpan), SymbolLiteral("frozen?", UnknownSpan)),
+              UnknownSpan
+            ),
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
+    it("parses interpolated double-quoted symbol literals") {
+      val input = """name = :"test_#{path}""""
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          Assign("name", SymbolLiteral("test_#{path}", UnknownSpan), UnknownSpan)
+        ), UnknownSpan)
+      )
+    }
+
     it("parses uppercase percent-Q strings") {
       val input = "message = %Q{ENSURE\\n}"
       val parsed = RubySubsetParser.parse(input)
@@ -1527,6 +1631,26 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
               StringLiteral("break"),
               StringLiteral("next"),
               StringLiteral("redo")
+            ), UnknownSpan),
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
+    it("parses percent symbol-array literals") {
+      val input = "keywords = %i[break next redo]"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          Assign(
+            "keywords",
+            ArrayLiteral(List(
+              SymbolLiteral("break", UnknownSpan),
+              SymbolLiteral("next", UnknownSpan),
+              SymbolLiteral("redo", UnknownSpan)
             ), UnknownSpan),
             UnknownSpan
           )
@@ -1695,6 +1819,27 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
       )
     }
 
+    it("parses call arguments with hash-rocket entries") {
+      val input = """assert_normal_exit %q{x}, "msg", ["INT"], :timeout => 10 or break"""
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+    }
+
+    it("parses command-style call with deep constant-path argument") {
+      val input = "extend Test::Unit::Assertions"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          ExprStmt(
+            Call(None, "extend", List(ConstRef(List("Test", "Unit", "Assertions"), UnknownSpan)), UnknownSpan),
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
     it("parses squiggly heredoc argument with trailing args") {
       val input =
         """assert_equal "false", <<~RUBY, "literal strings are mutable", "--disable-frozen-string-literal"
@@ -1743,6 +1888,26 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
       )
     }
 
+    it("parses single-quoted heredoc marker in arguments") {
+      val input =
+        """assert_normal_exit(<<'End', "msg") if false
+          |  puts :ok
+          |End
+          |""".stripMargin
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+    }
+
+    it("parses quoted heredoc marker with non-identifier delimiter") {
+      val input =
+        """src = <<-'},'
+          |  puts :ok
+          |},
+          |""".stripMargin
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+    }
+
     it("parses unary plus and minus operators") {
       val input = "line = -2; value = +line"
       val parsed = RubySubsetParser.parse(input)
@@ -1752,6 +1917,47 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
         ast == Program(List(
           Assign("line", UnaryOp("-", IntLiteral(2, UnknownSpan), UnknownSpan), UnknownSpan),
           Assign("value", UnaryOp("+", LocalVar("line", UnknownSpan), UnknownSpan), UnknownSpan)
+        ), UnknownSpan)
+      )
+    }
+
+    it("parses exponent and bitwise operators") {
+      val input = "value = ~1 & (2**8 | 0b1111_0000)"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          Assign(
+            "value",
+            BinaryOp(
+              UnaryOp("~", IntLiteral(1, UnknownSpan), UnknownSpan),
+              "&",
+              BinaryOp(
+                BinaryOp(IntLiteral(2, UnknownSpan), "**", IntLiteral(8, UnknownSpan), UnknownSpan),
+                "|",
+                IntLiteral(240, UnknownSpan),
+                UnknownSpan
+              ),
+              UnknownSpan
+            ),
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
+    it("parses base-prefixed and underscored integers") {
+      val input = "a = 0xFF; b = 1_000; c = 0d42; d = 0o12"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          Assign("a", IntLiteral(255, UnknownSpan), UnknownSpan),
+          Assign("b", IntLiteral(1000, UnknownSpan), UnknownSpan),
+          Assign("c", IntLiteral(42, UnknownSpan), UnknownSpan),
+          Assign("d", IntLiteral(10, UnknownSpan), UnknownSpan)
         ), UnknownSpan)
       )
     }
@@ -1912,6 +2118,28 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
             ArrayLiteral(List(
               ArrayLiteral(List(StringLiteral("a", UnknownSpan), IntLiteral(1, UnknownSpan)), UnknownSpan),
               ArrayLiteral(List(StringLiteral("b", UnknownSpan), IntLiteral(2, UnknownSpan)), UnknownSpan)
+            ), UnknownSpan),
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
+    it("parses array literals with trailing comma") {
+      val input =
+        """pairs = [
+          |  ["a", 1],
+          |]
+          |""".stripMargin
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          Assign(
+            "pairs",
+            ArrayLiteral(List(
+              ArrayLiteral(List(StringLiteral("a", UnknownSpan), IntLiteral(1, UnknownSpan)), UnknownSpan)
             ), UnknownSpan),
             UnknownSpan
           )

--- a/src/test/scala/com/github/kmizu/macro_peg/ruby/RubySubsetParserSpec.scala
+++ b/src/test/scala/com/github/kmizu/macro_peg/ruby/RubySubsetParserSpec.scala
@@ -89,6 +89,31 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
       )
     }
 
+    it("parses array literals with splat elements") {
+      val input = "x = [*head, 1]"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          Assign(
+            "x",
+            ArrayLiteral(List(
+              LocalVar("head", UnknownSpan),
+              IntLiteral(1, UnknownSpan)
+            ), UnknownSpan),
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
+    it("parses parenthesized postfix if expression in splat array element") {
+      val input = "x = [*((params.rest.name || :*) if params.rest && !params.rest.is_a?(ImplicitRestNode))]"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+    }
+
     it("returns parse failure for broken syntax") {
       val input = "def greet(; end"
       val parsed = RubySubsetParser.parse(input)
@@ -192,6 +217,12 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
       )
     }
 
+    it("parses parenthesized rescue expression in receiver chain") {
+      val input = "v = (foo rescue $!).local_variables"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+    }
+
     it("parses postfix while modifier on begin-rescue block") {
       val input =
         """begin
@@ -274,6 +305,36 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
         ast == Program(List(
           ExprStmt(
             Call(None, "assert_equal", List(StringLiteral("a", UnknownSpan), StringLiteral("b", UnknownSpan)), UnknownSpan),
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
+    it("parses command-style call with parenthesized first arg and trailing args") {
+      val input = """assert_equal (+"ア").force_encoding(Encoding::SHIFT_JIS), slice"""
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          ExprStmt(
+            Call(
+              None,
+              "assert_equal",
+              List(
+                Call(
+                  Some(
+                    UnaryOp("+", StringLiteral("ア", UnknownSpan), UnknownSpan)
+                  ),
+                  "force_encoding",
+                  List(ConstRef(List("Encoding", "SHIFT_JIS"), UnknownSpan)),
+                  UnknownSpan
+                ),
+                LocalVar("slice", UnknownSpan)
+              ),
+              UnknownSpan
+            ),
             UnknownSpan
           )
         ), UnknownSpan)
@@ -387,6 +448,12 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
       assert(parsed.isRight)
     }
 
+    it("does not split keyword-prefix local vars in chained calls") {
+      val input = "method_node = class_node.body.body.first"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+    }
+
     it("parses brace block attached to call") {
       val input = "add(1, 2) { |x| puts x }"
       val parsed = RubySubsetParser.parse(input)
@@ -429,6 +496,14 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
           Assign("y", IntLiteral(2), UnknownSpan)
         ), UnknownSpan)
       )
+    }
+
+    it("parses newline-separated statements with trailing inline comment") {
+      val input =
+        """Foo.foo # comment
+          |foo""".stripMargin
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
     }
 
     it("parses receiver parenthesized call with multiline do-end block") {
@@ -613,6 +688,23 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
       )
     }
 
+    it("parses return with postfix if and complex condition") {
+      val input = """return if RUBY_ENGINE != "ruby""""
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+    }
+
+    it("parses command arg starting with case expression") {
+      val input =
+        """puts case x
+          |when 1 then :one
+          |else :other
+          |end
+          |""".stripMargin
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+    }
+
     it("parses self expression and self receiver command call") {
       val input = "x = self.name; self.log 1"
       val parsed = RubySubsetParser.parse(input)
@@ -658,6 +750,27 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
       )
     }
 
+    it("parses receiver calls to begin/end keyword method names") {
+      val input = "x = 1.step.begin; y = 1.step.end"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          Assign(
+            "x",
+            Call(Some(Call(Some(IntLiteral(1)), "step", Nil, UnknownSpan)), "begin", Nil, UnknownSpan),
+            UnknownSpan
+          ),
+          Assign(
+            "y",
+            Call(Some(Call(Some(IntLiteral(1)), "step", Nil, UnknownSpan)), "end", Nil, UnknownSpan),
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
     it("parses constant path expressions") {
       val input = "x = JSON::Parser"
       val parsed = RubySubsetParser.parse(input)
@@ -678,6 +791,22 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
       assert(
         ast == Program(List(
           Assign("x", ConstRef(List("JSON", "Parser"), UnknownSpan), UnknownSpan)
+        ), UnknownSpan)
+      )
+    }
+
+    it("parses :: method call on constant path receiver") {
+      val input = "x = BOX1::BOX_B::yay"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          Assign(
+            "x",
+            Call(Some(ConstRef(List("BOX1", "BOX_B"), UnknownSpan)), "yay", Nil, UnknownSpan),
+            UnknownSpan
+          )
         ), UnknownSpan)
       )
     }
@@ -710,6 +839,21 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
       )
     }
 
+    it("parses adjacent string literals as one argument") {
+      val input = """assert_equal("ab", "a" "b")"""
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          ExprStmt(
+            Call(None, "assert_equal", List(StringLiteral("ab", UnknownSpan), StringLiteral("ab", UnknownSpan)), UnknownSpan),
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
     it("parses percent-quoted string literals") {
       val input = "assert_equal %q{ok}, %{ng}"
       val parsed = RubySubsetParser.parse(input)
@@ -735,6 +879,30 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
           Assign(
             "x",
             Call(Some(ConstRef(List("ENV"), UnknownSpan)), "[]", List(StringLiteral("HOME")), UnknownSpan),
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
+    it("parses bracket call with keyword label arguments") {
+      val input = "paths = Dir[glob_pattern, base: BASE]"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          Assign(
+            "paths",
+            Call(
+              Some(ConstRef(List("Dir"), UnknownSpan)),
+              "[]",
+              List(
+                LocalVar("glob_pattern", UnknownSpan),
+                HashLiteral(List(SymbolLiteral("base", UnknownSpan) -> ConstRef(List("BASE"), UnknownSpan)), UnknownSpan)
+              ),
+              UnknownSpan
+            ),
             UnknownSpan
           )
         ), UnknownSpan)
@@ -824,6 +992,17 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
           )
         ), UnknownSpan)
       )
+    }
+
+    it("parses do-end block with rescue clause") {
+      val input =
+        """Thread.new do
+          |  work
+          |rescue RangeError
+          |  recover
+          |end""".stripMargin
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
     }
 
     it("parses def body with bare ensure section") {
@@ -998,6 +1177,19 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
       )
     }
 
+    it("parses dashed special global variables like $-0") {
+      val input = "x = $-0; $-0 = \",\""
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          Assign("x", GlobalVar("$-0", UnknownSpan), UnknownSpan),
+          Assign("$-0", StringLiteral(",", UnknownSpan), UnknownSpan)
+        ), UnknownSpan)
+      )
+    }
+
     it("parses multiple assignment from expression") {
       val input = "faildesc, t = super"
       val parsed = RubySubsetParser.parse(input)
@@ -1010,6 +1202,18 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
             LocalVar("super", UnknownSpan),
             UnknownSpan
           )
+        ), UnknownSpan)
+      )
+    }
+
+    it("parses assignment whose rhs is def expression") {
+      val input = "$def_retval_in_namespace = def boooo; \"boo\"; end"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          Assign("$def_retval_in_namespace", SymbolLiteral("boooo", UnknownSpan), UnknownSpan)
         ), UnknownSpan)
       )
     }
@@ -1032,6 +1236,53 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
             List(
               Assign("sum", BinaryOp(LocalVar("sum", UnknownSpan), "+", LocalVar("x", UnknownSpan), UnknownSpan), UnknownSpan)
             ),
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
+    it("parses open-ended range expressions") {
+      val input = "a = items[1..]; b = items[..limit]"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          Assign(
+            "a",
+            Call(
+              Some(LocalVar("items", UnknownSpan)),
+              "[]",
+              List(RangeExpr(IntLiteral(1, UnknownSpan), NilLiteral(UnknownSpan), exclusive = false, UnknownSpan)),
+              UnknownSpan
+            ),
+            UnknownSpan
+          ),
+          Assign(
+            "b",
+            Call(
+              Some(LocalVar("items", UnknownSpan)),
+              "[]",
+              List(RangeExpr(NilLiteral(UnknownSpan), LocalVar("limit", UnknownSpan), exclusive = false, UnknownSpan)),
+              UnknownSpan
+            ),
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
+    it("parses exclusive range expressions with hex end") {
+      val input = "x = 0...0x100"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          Assign(
+            "x",
+            RangeExpr(IntLiteral(0, UnknownSpan), IntLiteral(256, UnknownSpan), exclusive = true, UnknownSpan),
             UnknownSpan
           )
         ), UnknownSpan)
@@ -1172,6 +1423,69 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
       )
     }
 
+    it("parses nameless rest parameters in def") {
+      val input = "def method_missing(name, *); name; end"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          Def(
+            "method_missing",
+            List("name", "*"),
+            List(ExprStmt(LocalVar("name", UnknownSpan), UnknownSpan)),
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
+    it("parses forwarding (...) parameter and argument") {
+      val input = "def method_missing(...); ::String.public_send(...); end"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          Def(
+            "method_missing",
+            List("..."),
+            List(
+              ExprStmt(
+                Call(
+                  Some(ConstRef(List("String"), UnknownSpan)),
+                  "public_send",
+                  List(LocalVar("...", UnknownSpan)),
+                  UnknownSpan
+                ),
+                UnknownSpan
+              )
+            ),
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
+    it("parses bare visibility keyword call in class body") {
+      val input = "class C; private; def f; true; end; end"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          ClassDef(
+            "C",
+            List(
+              ExprStmt(Call(None, "private", Nil, UnknownSpan), UnknownSpan),
+              Def("f", Nil, List(ExprStmt(BoolLiteral(true, UnknownSpan), UnknownSpan)), UnknownSpan)
+            ),
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
     it("parses lambda literal argument with bare parameter") {
       val input = "add_assertion testsrc, -> as do; as.id = 1; end"
       val parsed = RubySubsetParser.parse(input)
@@ -1221,6 +1535,26 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
               Some(LocalVar("ts", UnknownSpan)),
               "each",
               List(SymbolLiteral("kill", UnknownSpan)),
+              UnknownSpan
+            ),
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
+    it("parses symbol block-pass argument with keyword symbol") {
+      val input = "seq.first(5).map(&:class)"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          ExprStmt(
+            Call(
+              Some(Call(Some(LocalVar("seq", UnknownSpan)), "first", List(IntLiteral(5)), UnknownSpan)),
+              "map",
+              List(SymbolLiteral("class", UnknownSpan)),
               UnknownSpan
             ),
             UnknownSpan
@@ -1402,6 +1736,34 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
       )
     }
 
+    it("parses index compound assignment expression") {
+      val input = "memo[0] += i"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          ExprStmt(
+            Call(
+              Some(LocalVar("memo", UnknownSpan)),
+              "[]=",
+              List(
+                IntLiteral(0, UnknownSpan),
+                BinaryOp(
+                  Call(Some(LocalVar("memo", UnknownSpan)), "[]", List(IntLiteral(0, UnknownSpan)), UnknownSpan),
+                  "+",
+                  LocalVar("i", UnknownSpan),
+                  UnknownSpan
+                )
+              ),
+              UnknownSpan
+            ),
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
     it("parses receiver compound assignment") {
       val input = "self.columns += 1"
       val parsed = RubySubsetParser.parse(input)
@@ -1491,6 +1853,18 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
       )
     }
 
+    it("parses operator method names in def definitions") {
+      val input =
+        """class Box
+          |  def [](n); @args[n]; end
+          |  def []=(n, value); @args[n] = value; end
+          |  def self.<=>(other); 0; end
+          |end
+          |""".stripMargin
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+    }
+
     it("parses nested percent-q parentheses strings") {
       val input = "x = %q( Object.const_defined?(:C) )"
       val parsed = RubySubsetParser.parse(input)
@@ -1551,6 +1925,27 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
       )
     }
 
+    it("parses percent-x command literals with call chaining") {
+      val input = "x = %x(objdump --section=.text --syms #{path}).split(\"\\n\")"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          Assign(
+            "x",
+            Call(
+              Some(StringLiteral("objdump --section=.text --syms #{path}", UnknownSpan)),
+              "split",
+              List(StringLiteral("\n", UnknownSpan)),
+              UnknownSpan
+            ),
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
     it("parses symbol literals with variable-like names") {
       val input = "trace_var(:$a); trace_var(:@x); trace_var(:@@y)"
       val parsed = RubySubsetParser.parse(input)
@@ -1590,6 +1985,18 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
             ),
             UnknownSpan
           )
+        ), UnknownSpan)
+      )
+    }
+
+    it("parses unicode bare symbol literals") {
+      val input = "name = :ą"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          Assign("name", SymbolLiteral("ą", UnknownSpan), UnknownSpan)
         ), UnknownSpan)
       )
     }
@@ -1746,6 +2153,16 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
           )
         ), UnknownSpan)
       )
+    }
+
+    it("parses multiline || continuation with unary rhs") {
+      val input =
+        """compare = !(current.is_a?(StringNode) ||
+          |            current.is_a?(XStringNode)) ||
+          |!current.opening&.start_with?("<<")
+          |""".stripMargin
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
     }
 
     it("parses label-style hash entries") {
@@ -1908,6 +2325,28 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
       assert(parsed.isRight)
     }
 
+    it("does not mis-detect heredoc opener text inside string literals") {
+      val input =
+        """pairs = ["<<-HERE\n", "\nHERE"]
+          |result = Prism.parse(<<~RUBY)
+          |  %w[\x81\x5c]
+          |RUBY
+          |""".stripMargin
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+    }
+
+    it("keeps interpolation markers literal in normalized heredoc content") {
+      val input =
+        """code = <<~'RUBY'.strip
+          |  <<A+B
+          |  #{C
+          |RUBY
+          |""".stripMargin
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+    }
+
     it("parses unary plus and minus operators") {
       val input = "line = -2; value = +line"
       val parsed = RubySubsetParser.parse(input)
@@ -1958,6 +2397,20 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
           Assign("b", IntLiteral(1000, UnknownSpan), UnknownSpan),
           Assign("c", IntLiteral(42, UnknownSpan), UnknownSpan),
           Assign("d", IntLiteral(10, UnknownSpan), UnknownSpan)
+        ), UnknownSpan)
+      )
+    }
+
+    it("parses numeric literals with r/i suffixes") {
+      val input = "a = 1r; b = 2i; c = 3.5r"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          Assign("a", RationalLiteral(IntLiteral(1, UnknownSpan), UnknownSpan), UnknownSpan),
+          Assign("b", ImaginaryLiteral(IntLiteral(2, UnknownSpan), UnknownSpan), UnknownSpan),
+          Assign("c", RationalLiteral(FloatLiteral(3.5, UnknownSpan), UnknownSpan), UnknownSpan)
         ), UnknownSpan)
       )
     }
@@ -2040,6 +2493,12 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
           )
         ), UnknownSpan)
       )
+    }
+
+    it("parses while with unparenthesized assignment expression condition") {
+      val input = "while node = queue.shift; return node if node; end"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
     }
 
     it("parses compound assignment in expression context") {
@@ -2260,6 +2719,27 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
       assert(parsed.isRight)
     }
 
+    it("parses triple-equals with constant paths") {
+      val input = "x = Prism::StringNode === y"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          Assign(
+            "x",
+            BinaryOp(
+              ConstRef(List("Prism", "StringNode"), UnknownSpan),
+              "===",
+              LocalVar("y", UnknownSpan),
+              UnknownSpan
+            ),
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
     it("parses case when else expression") {
       val input =
         """case prefix_suffix
@@ -2295,6 +2775,152 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
           )
         ), UnknownSpan)
       )
+    }
+    it("parses while...do...end") {
+      val input = "while x > 0 do\n  x -= 1\nend"
+      assert(RubySubsetParser.parse(input).isRight)
+    }
+
+    it("parses until...do...end") {
+      val input = "until x == 0 do\n  x -= 1\nend"
+      assert(RubySubsetParser.parse(input).isRight)
+    }
+
+    it("parses for...in...do...end") {
+      val input = "for i in 1..10 do\n  puts i\nend"
+      assert(RubySubsetParser.parse(input).isRight)
+    }
+
+    it("parses if...then...end") {
+      val input = "if x > 0 then\n  puts x\nend"
+      assert(RubySubsetParser.parse(input).isRight)
+    }
+
+    it("parses unless...then...end") {
+      val input = "unless x == 0 then\n  puts x\nend"
+      assert(RubySubsetParser.parse(input).isRight)
+    }
+
+    it("parses when...then... in case") {
+      val input = "case x\nwhen 1 then puts \"one\"\nwhen 2 then puts \"two\"\nend"
+      assert(RubySubsetParser.parse(input).isRight)
+    }
+
+    it("strips __END__ section") {
+      val input = "x = 1\n__END__\nsome data\nthat should be ignored"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      assert(parsed.isRight)
+      assert(parsed.toOption.get.statements.length == 1)
+    }
+
+    it("parses begin...end as expression on RHS of assignment") {
+      val input = "x = begin\n  1 + 2\nrescue\n  0\nend"
+      assert(RubySubsetParser.parse(input).isRight)
+    }
+
+    it("parses assignment with newline before begin...end expression") {
+      val input = "x =\n  begin\n    1\n  ensure\n    2\n  end"
+      assert(RubySubsetParser.parse(input).isRight)
+    }
+
+    it("parses if...end as expression on RHS of assignment") {
+      val input = "x = if cond\n  1\nelse\n  2\nend"
+      assert(RubySubsetParser.parse(input).isRight)
+    }
+
+    it("parses case...end as expression on RHS of assignment") {
+      val input = "x = case y\nwhen 1 then \"one\"\nelse \"other\"\nend"
+      assert(RubySubsetParser.parse(input).isRight)
+    }
+
+    it("parses quote-delimited percent word and symbol arrays") {
+      val input = "a = %w\"x y\"; b = %w'a b'; c = %i\"foo bar\""
+      assert(RubySubsetParser.parse(input).isRight)
+    }
+
+    it("parses chained assignment on rhs") {
+      val input = "a = b = c = 1"
+      assert(RubySubsetParser.parse(input).isRight)
+    }
+
+    it("parses starred and indexed multi assignment") {
+      val input = "*a = nil; ENV[n0], e0 = e0, ENV[n0]"
+      assert(RubySubsetParser.parse(input).isRight)
+    }
+
+    it("parses safe-navigation assignment") {
+      val input = "o&.x = 6"
+      assert(RubySubsetParser.parse(input).isRight)
+    }
+
+    it("parses def with backtick method name") {
+      val input =
+        """def `(command)`
+          |  command
+          |end""".stripMargin
+      assert(RubySubsetParser.parse(input).isRight)
+    }
+
+    it("parses question-mark character literal") {
+      val input = "x = ?a"
+      assert(RubySubsetParser.parse(input).isRight)
+    }
+
+    it("parses nil block and keyword rest parameters") {
+      val input = "def mnb(&nil) end; def mnk(**nil) end"
+      assert(RubySubsetParser.parse(input).isRight)
+    }
+
+    it("parses block pass with expression") {
+      val input = "(1..3).each(&lambda{})"
+      assert(RubySubsetParser.parse(input).isRight)
+    }
+
+    it("parses single-quoted symbol literal") {
+      val input = "o.instance_variable_get(:'@')"
+      assert(RubySubsetParser.parse(input).isRight)
+    }
+
+    it("parses hash literal with double-splat entry") {
+      val input = "defined?({**a})"
+      assert(RubySubsetParser.parse(input).isRight)
+    }
+
+    it("parses case-in clauses") {
+      val input =
+        """case x
+          |in 0
+          |  true
+          |else
+          |  false
+          |end""".stripMargin
+      assert(RubySubsetParser.parse(input).isRight)
+    }
+
+    it("parses unary operator method definition") {
+      val input = "class C; def -@; :ok; end; end"
+      assert(RubySubsetParser.parse(input).isRight)
+    }
+
+    it("parses block pass with call-chain expression") {
+      val input = "Thread.new(&method(:sleep).to_proc)"
+      assert(RubySubsetParser.parse(input).isRight)
+    }
+
+    it("parses for statement with multiple bindings") {
+      val input = "for x,y in cache.sort_by {|z| z[0] % 3 }; puts x; end"
+      assert(RubySubsetParser.parse(input).isRight)
+    }
+
+    it("parses singleton class expression chained with class_eval") {
+      val input = "class << o; self; end.class_eval do; x = 1; end"
+      assert(RubySubsetParser.parse(input).isRight)
+    }
+
+    it("parses backtick symbol literal") {
+      val input = "marshal_equal(:`)"
+      assert(RubySubsetParser.parse(input).isRight)
     }
   }
 }

--- a/src/test/scala/com/github/kmizu/macro_peg/ruby/RubySubsetParserSpec.scala
+++ b/src/test/scala/com/github/kmizu/macro_peg/ruby/RubySubsetParserSpec.scala
@@ -167,6 +167,67 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
       )
     }
 
+    it("parses postfix rescue modifier") {
+      val input = "r.close rescue nil"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          BeginRescue(
+            List(ExprStmt(Call(Some(LocalVar("r", UnknownSpan)), "close", Nil, UnknownSpan), UnknownSpan)),
+            List(
+              RescueClause(
+                Nil,
+                None,
+                List(ExprStmt(NilLiteral(UnknownSpan), UnknownSpan)),
+                UnknownSpan
+              )
+            ),
+            Nil,
+            Nil,
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
+    it("parses postfix while modifier on begin-rescue block") {
+      val input =
+        """begin
+          |  x = 1
+          |rescue E
+          |  x = 2
+          |end while ready""".stripMargin
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          WhileExpr(
+            LocalVar("ready", UnknownSpan),
+            List(
+              BeginRescue(
+                List(Assign("x", IntLiteral(1, UnknownSpan), UnknownSpan)),
+                List(
+                  RescueClause(
+                    List(ConstRef(List("E"), UnknownSpan)),
+                    None,
+                    List(Assign("x", IntLiteral(2, UnknownSpan), UnknownSpan)),
+                    UnknownSpan
+                  )
+                ),
+                Nil,
+                Nil,
+                UnknownSpan
+              )
+            ),
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
     it("parses command-style calls without parentheses") {
       val input = "puts :ok; add 1, 2"
       val parsed = RubySubsetParser.parse(input)
@@ -180,6 +241,21 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
           ),
           ExprStmt(
             Call(None, "add", List(IntLiteral(1), IntLiteral(2)), UnknownSpan),
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
+    it("parses float literal in command-style call arguments") {
+      val input = "sleep 0.1"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          ExprStmt(
+            Call(None, "sleep", List(FloatLiteral(0.1, UnknownSpan)), UnknownSpan),
             UnknownSpan
           )
         ), UnknownSpan)
@@ -447,6 +523,28 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
       )
     }
 
+    it("parses return with multiple values") {
+      val input = "def f; return out, err; end"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          Def(
+            "f",
+            Nil,
+            List(
+              Return(
+                Some(ArrayLiteral(List(LocalVar("out", UnknownSpan), LocalVar("err", UnknownSpan)), UnknownSpan)),
+                UnknownSpan
+              )
+            ),
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
     it("parses bare return with postfix modifier") {
       val input = "return if done"
       val parsed = RubySubsetParser.parse(input)
@@ -695,6 +793,94 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
       )
     }
 
+    it("parses def body with rescue-else-ensure sections") {
+      val input =
+        """def f
+          |  x = 1
+          |rescue Error => e
+          |  x = 2
+          |else
+          |  x = 3
+          |ensure
+          |  x = 4
+          |end""".stripMargin
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          Def(
+            "f",
+            Nil,
+            List(
+              BeginRescue(
+                List(Assign("x", IntLiteral(1, UnknownSpan), UnknownSpan)),
+                List(
+                  RescueClause(
+                    List(ConstRef(List("Error"), UnknownSpan)),
+                    Some("e"),
+                    List(Assign("x", IntLiteral(2, UnknownSpan), UnknownSpan)),
+                    UnknownSpan
+                  )
+                ),
+                List(Assign("x", IntLiteral(3, UnknownSpan), UnknownSpan)),
+                List(Assign("x", IntLiteral(4, UnknownSpan), UnknownSpan)),
+                UnknownSpan
+              )
+            ),
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
+    it("parses def body with multiple rescue clauses") {
+      val input =
+        """def f
+          |  x = 1
+          |rescue E1
+          |  x = 2
+          |rescue E2 => err
+          |  x = 3
+          |ensure
+          |  x = 4
+          |end""".stripMargin
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          Def(
+            "f",
+            Nil,
+            List(
+              BeginRescue(
+                List(Assign("x", IntLiteral(1, UnknownSpan), UnknownSpan)),
+                List(
+                  RescueClause(
+                    List(ConstRef(List("E1"), UnknownSpan)),
+                    None,
+                    List(Assign("x", IntLiteral(2, UnknownSpan), UnknownSpan)),
+                    UnknownSpan
+                  ),
+                  RescueClause(
+                    List(ConstRef(List("E2"), UnknownSpan)),
+                    Some("err"),
+                    List(Assign("x", IntLiteral(3, UnknownSpan), UnknownSpan)),
+                    UnknownSpan
+                  )
+                ),
+                Nil,
+                List(Assign("x", IntLiteral(4, UnknownSpan), UnknownSpan)),
+                UnknownSpan
+              )
+            ),
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
     it("parses singleton class definition") {
       val input =
         """class << self
@@ -733,6 +919,18 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
           Assign("$z", IntLiteral(3), UnknownSpan),
           Assign("w", BinaryOp(InstanceVar("@x", UnknownSpan), "+", ClassVar("@@y", UnknownSpan), UnknownSpan), UnknownSpan),
           Assign("v", GlobalVar("$z", UnknownSpan), UnknownSpan)
+        ), UnknownSpan)
+      )
+    }
+
+    it("parses special global variable $?") {
+      val input = "status = $?"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          Assign("status", GlobalVar("$?", UnknownSpan), UnknownSpan)
         ), UnknownSpan)
       )
     }
@@ -894,6 +1092,60 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
       )
     }
 
+    it("parses keyword parameters with defaults in def") {
+      val input = "def f(opt = '', timeout: BT.timeout, **argh); end"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          Def(
+            "f",
+            List("opt", "timeout:", "**argh"),
+            Nil,
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
+    it("parses lambda literal argument with bare parameter") {
+      val input = "add_assertion testsrc, -> as do; as.id = 1; end"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          ExprStmt(
+            Call(
+              None,
+              "add_assertion",
+              List(
+                LocalVar("testsrc", UnknownSpan),
+                LambdaLiteral(
+                  List("as"),
+                  List(
+                    ExprStmt(
+                      Call(
+                        Some(LocalVar("as", UnknownSpan)),
+                        "id=",
+                        List(IntLiteral(1, UnknownSpan)),
+                        UnknownSpan
+                      ),
+                      UnknownSpan
+                    )
+                  ),
+                  UnknownSpan
+                )
+              ),
+              UnknownSpan
+            ),
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
     it("parses symbol block-pass argument") {
       val input = "ts.each(&:kill)"
       val parsed = RubySubsetParser.parse(input)
@@ -939,6 +1191,27 @@ class RubySubsetParserSpec extends AnyFunSpec with Diagrams {
             ),
             List(ExprStmt(Call(None, "ok!", List(IntLiteral(1)), UnknownSpan), UnknownSpan)),
             Nil,
+            UnknownSpan
+          )
+        ), UnknownSpan)
+      )
+    }
+
+    it("parses modulo operator in expression") {
+      val input = "msg = '%.2f' % sec"
+      val parsed = RubySubsetParser.parse(input)
+      assert(parsed.isRight)
+      val ast = parsed.toOption.get
+      assert(
+        ast == Program(List(
+          Assign(
+            "msg",
+            BinaryOp(
+              StringLiteral("%.2f", UnknownSpan),
+              "%",
+              LocalVar("sec", UnknownSpan),
+              UnknownSpan
+            ),
             UnknownSpan
           )
         ), UnknownSpan)


### PR DESCRIPTION
## Summary
- add parser-level recursion diagnostics and memoization support in `MacroParsers`
- extend Ruby subset grammar for high-impact corpus constructs (`%w/%i` quote delimiters, safe-nav assignment, chained assignment RHS, richer multi-assign, backtick def names, char literal `?a`, `case ... in`, singleton-class chaining, block-pass call-chain forms)
- expand corpus tooling (`RubyCorpusRunner`) and regression coverage in `RubySubsetParserSpec` / `MacroParsersAdvancedSpec`

## Verification
- `sbt --batch test`
- `RUBY_CORPUS_TIMEOUT_MS=5000 sbt --batch "runMain com.github.kmizu.macro_peg.ruby.RubyCorpusRunner"`

## Coverage notes
- full corpus 5s timeout runs improved from earlier baseline in this cycle, with a best observed `197/301 (65.45%)` and latest rerun `193/301 (64.12%)` under heavy GC pressure.
