### PR TITLE
build: pin sbt 1.12.15 and keep scala-steward off sbt 2.x

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,4 @@
+updates.ignore = [
+  # sbt 2.x has no artifacts for sbt-pgp, sbt-sonatype, sbt-release or sbt-scoverage yet
+  { groupId = "org.scala-sbt", artifactId = "sbt" }
+]

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=2.0.5
+sbt.version=1.12.15


### PR DESCRIPTION
## Summary
- `main` has been failing CI since the scala-steward bump to sbt 2.0.5 (d50c7f5): `sbt-pgp`, `sbt-sonatype`, `sbt-release` and `sbt-scoverage` have no sbt 2 artifacts, so dependency resolution fails before anything compiles.
- Pin `sbt.version` back to 1.12.15 (the last known-good version).
- Add `.scala-steward.conf` ignoring `org.scala-sbt:sbt` so the bot does not re-open the same bump.

The same pin is already in #200 (feat/ruby-peg-grammar) as de1c829; this applies it to `main` independently.

## Test plan
- [x] `sbt Test/compile` on this branch starts sbt 1.12.15 and compiles
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jQpL8pgDmhRGdkNKAsP1s