### PR TITLE
build: move to sbt 2.0.8

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -37,7 +37,7 @@ jobs:
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
         run: |
-          VERSION=$(grep 'version in ThisBuild' version.sbt | sed 's/.*"\(.*\)"/\1/')
+          VERSION=$(grep 'ThisBuild / version' version.sbt | sed 's/.*"\(.*\)"/\1/')
           if [[ "$VERSION" == *-SNAPSHOT ]]; then
             sbt publishSigned
           else

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,3 @@
-import ReleaseTransformations._
-
 organization := "com.github.kmizu"
 
 name := "macro_peg"
@@ -12,98 +10,68 @@ val scaladocBranch = settingKey[String]("branch name for scaladoc -doc-source-ur
 
 scaladocBranch := "main"
 
-scalacOptions in (Compile, doc) ++= { Seq(
+Compile / doc / scalacOptions ++= Seq(
   "-sourcepath", baseDirectory.value.getAbsolutePath,
   "-doc-source-url", s"https://github.com/kmizu/macro_peg/tree/${scaladocBranch.value}€{FILE_PATH}.scala",
-)}
+)
 
-scalacOptions ++= {
-  Seq("-unchecked", "-deprecation", "-feature", "-language:implicitConversions")
-}
+scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-language:implicitConversions")
 
 libraryDependencies ++= Seq(
   ("com.github.kmizu" %% "scomb" % "0.9.0").cross(CrossVersion.for3Use2_13),
   "org.scalatest" %% "scalatest" % "3.2.20" % Test,
   "org.scalatestplus" %% "scalacheck-1-19" % "3.2.20.0" % Test,
-  "org.scalacheck" %% "scalacheck" % "1.19.0" % "test"
+  "org.scalacheck" %% "scalacheck" % "1.19.0" % Test
 )
 
 Test / fork := true
 Test / javaOptions += "-Xss128m"
 Test / parallelExecution := false
 
-
-initialCommands in console += {
+console / initialCommands += {
   Iterator(
     "com.github.kmizu.macro_peg.combinator.MacroParsers._"
-  ).map("import "+).mkString("\n")
+  ).map("import " + _).mkString("\n")
 }
 
-pomExtra := (
-  <url>https://github.com/kmizu/macro_peg</url>
-  <licenses>
-    <license>
-      <name>The MIT License</name>
-      <url>http://www.opensource.org/licenses/MIT</url>
-      <distribution>repo</distribution>
-    </license>
-  </licenses>
-  <scm>
-    <url>git@github.com:kmizu/macro_peg.git</url>
-    <connection>scm:git:git@github.com:kmizu/macro_peg.git</connection>
-  </scm>
-  <developers>
-    <developer>
-      <id>kmizu</id>
-      <name>Kota Mizushima</name>
-      <url>https://github.com/kmizu</url>
-    </developer>
-  </developers>
-)
+// ---- POM metadata (sbt 2 builds are Scala 3, so no XML literals) ----
 
-publishTo := {
-  val nexus = "https://oss.sonatype.org/"
-  if (version.value.endsWith("-SNAPSHOT"))
-    Some("snapshots" at nexus+"content/repositories/snapshots")
-  else
-    Some("releases" at nexus+"service/local/staging/deploy/maven2")
+homepage := Some(url("https://github.com/kmizu/macro_peg"))
+licenses := Seq("MIT" -> url("http://www.opensource.org/licenses/MIT"))
+scmInfo := Some(
+  ScmInfo(
+    url("https://github.com/kmizu/macro_peg"),
+    "scm:git:git@github.com:kmizu/macro_peg.git"
+  )
+)
+developers := List(
+  Developer("kmizu", "Kota Mizushima", "", url("https://github.com/kmizu"))
+)
+pomIncludeRepository := (_ => false)
+
+// ---- Publishing via Sonatype Central (built into sbt 2; no sbt-sonatype needed) ----
+//
+// Releases:  `publishSigned` stages into target/sona-staging, then `sonaRelease` uploads
+//            the bundle to the Central Portal and releases it.
+// Snapshots: `publishSigned` uploads directly to the Central snapshots repository.
+
+ThisBuild / publishTo := {
+  val centralSnapshots = "https://central.sonatype.com/repository/maven-snapshots/"
+  if (version.value.endsWith("-SNAPSHOT")) Some("central-snapshots" at centralSnapshots)
+  else localStaging.value
 }
 
 credentials ++= {
-  val sonatype = ("Sonatype Nexus Repository Manager", "oss.sonatype.org")
-  def loadMavenCredentials(file: java.io.File) : Seq[Credentials] = {
-    xml.XML.loadFile(file) \ "servers" \ "server" map (s => {
-      val host = (s \ "id").text
-      val realm = if (host == sonatype._2) sonatype._1 else "Unknown"
-      Credentials(realm, host, (s \ "username").text, (s \ "password").text)
-    })
-  }
-  val ivyCredentials   = Path.userHome / ".ivy2" / ".credentials"
-  val mavenCredentials = Path.userHome / ".m2"   / "settings.xml"
+  val host = "central.sonatype.com"
+  val realm = "Sonatype Central"
   val envCredentials = for {
     u <- sys.env.get("SONATYPE_USERNAME")
     p <- sys.env.get("SONATYPE_PASSWORD")
-  } yield Credentials(sonatype._1, sonatype._2, u, p)
-  envCredentials.toSeq ++ ((ivyCredentials.asFile, mavenCredentials.asFile) match {
-    case (ivy, _) if ivy.canRead => Credentials(ivy) :: Nil
-    case (_, mvn) if mvn.canRead => loadMavenCredentials(mvn)
-    case _ => Nil
-  })
+  } yield Credentials(realm, host, u, p)
+  val ivyCredentials = file(sys.props("user.home")) / ".ivy2" / ".credentials"
+  envCredentials.toSeq ++ (if (ivyCredentials.canRead) Seq(Credentials(ivyCredentials)) else Nil)
 }
 
 pgpPassphrase := sys.env.get("PGP_PASSPHRASE").map(_.toArray)
 
-releaseProcess := Seq[ReleaseStep](
-  checkSnapshotDependencies,
-  inquireVersions,
-  runClean,
-  runTest,
-  setReleaseVersion,
-  commitReleaseVersion,
-  tagRelease,
-  releaseStepCommandAndRemaining("publishSigned"),
-  releaseStepCommand("sonatypeReleaseAll"),
-  setNextVersion,
-  commitNextVersion,
-  pushChanges
-)
+// releaseProcess and the README update step live in release.sbt.

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.15
+sbt.version=2.0.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,3 @@
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.12.2")
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.12")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.1.0")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.2")
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.5.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.4.4")

--- a/release.sbt
+++ b/release.sbt
@@ -2,28 +2,26 @@ import sbtrelease._
 import ReleaseStateTransformations._
 import scala.sys.process._
 
-val sonatypeURL = "https://oss.sonatype.org/service/local/repositories/"
-
+// Rewrites the `libraryDependencies += ...` line in README.md to the version being released
+// (or the next snapshot) and commits it.
 val updateReadme: State => State = { state =>
   val extracted = Project.extract(state)
-  val scalaV = extracted get scalaBinaryVersion
-  val v = extracted get version
-  val org =  extracted get organization
-  val n = extracted get name
-  val snapshotOrRelease = if(extracted get isSnapshot) "snapshots" else "releases"
+  val v = extracted.get(version)
+  val org = extracted.get(organization)
+  val n = extracted.get(name)
+  val baseDir = extracted.get(baseDirectory)
   val readme = "README.md"
-  val readmeFile = file(readme)
-  val newReadme = Predef.augmentString(IO.read(readmeFile)).lines.map{ line =>
+  val readmeFile = baseDir / readme
+  val newReadme = IO.read(readmeFile).linesIterator.map { line =>
     val matchReleaseOrSnapshot = line.contains("SNAPSHOT") == v.contains("SNAPSHOT")
-    if(line.startsWith("libraryDependencies") && matchReleaseOrSnapshot){
+    if (line.startsWith("libraryDependencies") && matchReleaseOrSnapshot) {
       s"""libraryDependencies += "${org}" %% "${n}" % "$v""""
-    }else line
+    } else line
   }.mkString("", "\n", "\n")
   IO.write(readmeFile, newReadme)
-  val git = new Git(extracted get baseDirectory)
-  git.add(readme) ! state.log
-  git.commit("update " + readme, false, false) ! state.log
-  "git diff HEAD^" ! state.log
+  Process(Seq("git", "add", readme), baseDir) ! state.log
+  Process(Seq("git", "commit", "-m", "update " + readme), baseDir) ! state.log
+  Process(Seq("git", "diff", "HEAD^"), baseDir) ! state.log
   state
 }
 
@@ -31,6 +29,9 @@ commands += Command.command("updateReadme")(updateReadme)
 
 val updateReadmeProcess: ReleaseStep = updateReadme
 
+// Releases go to Sonatype Central through sbt 2's built-in support:
+// `publishSigned` stages into target/sona-staging (see publishTo in build.sbt),
+// then `sonaRelease` uploads the bundle to the Central Portal and releases it.
 releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,
   inquireVersions,
@@ -40,22 +41,12 @@ releaseProcess := Seq[ReleaseStep](
   commitReleaseVersion,
   updateReadmeProcess,
   tagRelease,
-  ReleaseStep(
-    action = { state =>
-      val extracted = Project extract state
-      extracted.runAggregated(PgpKeys.publishSigned in Global in extracted.get(thisProjectRef), state)
-    },
-    enableCrossBuild = true
-  ),
+  releaseStepCommandAndRemaining("publishSigned"),
+  releaseStepCommand("sonaRelease"),
   setNextVersion,
   commitNextVersion,
   updateReadmeProcess,
-  releaseStepCommand("sonatypeReleaseAll"),
   pushChanges
 )
 
-releaseCrossBuild := true
-
-releaseTagName := {
-  "releases/" + (version in ThisBuild).value
-}
+releaseTagName := "releases/" + (ThisBuild / version).value

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.1-SNAPSHOT"
+ThisBuild / version := "0.1.1-SNAPSHOT"


### PR DESCRIPTION
## Summary
CI on `main` has been red since scala-steward bumped `sbt.version` to 2.0.5: `sbt-pgp`, `sbt-sonatype`, `sbt-release` and `sbt-scoverage` at their pinned versions have no sbt 2 artifacts. This finishes the migration rather than pinning back (supersedes #201).

- **sbt 2.0.8**, `sbt-pgp` 2.3.2 and `sbt-release` 1.5.0 (both `com.github.sbt`), `sbt-scoverage` 2.4.4.
- **`sbt-sonatype` removed.** It has no sbt 2 release; sbt 2 has Sonatype Central publishing built in. `publishTo` goes to `https://central.sonatype.com/repository/maven-snapshots/` for snapshots and to `localStaging` for releases, and `releaseProcess` runs `publishSigned` followed by the built-in `sonaRelease`. The old `oss.sonatype.org` endpoints (shut down in 2025) are gone.
- Build definition rewritten for Scala 3 (sbt 2): `pomExtra` XML → `homepage`/`licenses`/`scmInfo`/`developers`; `key in scope` → `scope / key`; `release.sbt` no longer uses `String#lines` or `sbtrelease.Git`.
- `version.sbt` uses `ThisBuild / version`; `snapshot.yml` greps for that.

### Things to check before the next release
- `SONATYPE_USERNAME` / `SONATYPE_PASSWORD` secrets must be a **Central Portal user token** (generated at central.sonatype.com), not OSSRH credentials. The build looks them up for host `central.sonatype.com`.
- `updateReadme` still rewrites the `libraryDependencies += ...` line in README.md.

## Test plan
- [x] `sbt Test/compile` under sbt 2.0.8 (Java 25 locally)
- [x] `makePom` produces MIT license, scm and developer entries
- [x] `testOnly` subset runs under the forked test JVM
- [ ] CI green (full test suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jQpL8pgDmhRGdkNKAsP1s