### PR TITLE
ci: read the PGP key from the PGP_SECRETS secret

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           restore-keys: sbt-cache-
       - name: Import GPG key
         env:
-          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          PGP_SECRET: ${{ secrets.PGP_SECRETS }}
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
         run: |
           echo "$PGP_SECRET" | base64 --decode | gpg --batch --import

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -25,7 +25,7 @@ jobs:
           restore-keys: sbt-cache-
       - name: Import GPG key
         env:
-          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          PGP_SECRET: ${{ secrets.PGP_SECRETS }}
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
         run: |
           echo "$PGP_SECRET" | base64 --decode | gpg --batch --import


### PR DESCRIPTION
## Summary
The Snapshot workflow fails on every push to `main` at "Import GPG key" with `gpg: no valid OpenPGP data found`. The step's env shows `PGP_SECRET:` empty: the repository secret is named **`PGP_SECRETS`** (see `gh secret list`), while `release.yml` and `snapshot.yml` read `secrets.PGP_SECRET`. This points both workflows at the secret that actually exists.

Alternative would be renaming the secret; changing the workflows keeps it a reviewable code change.

## Test plan
- [ ] Snapshot workflow on `main` gets past "Import GPG key" after merge
- Note: publishing itself also needs `SONATYPE_USERNAME` / `SONATYPE_PASSWORD` to be a Central Portal user token (sbt 2 built-in publishing, see #202)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jQpL8pgDmhRGdkNKAsP1s