### PR TITLE
docs: point README at the released 0.1.1 and document snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ CharacterClass<- '[' '^'? (!']' .)+ ']'
 Add the library to your `build.sbt`:
 
 ```scala
+libraryDependencies += "com.github.kmizu" %% "macro_peg" % "0.1.1"
+```
+
+Snapshots are published to the Central snapshots repository on every push to `main`:
+
+```scala
+resolvers += Resolver.sonatypeCentralSnapshots
 libraryDependencies += "com.github.kmizu" %% "macro_peg" % "0.1.2-SNAPSHOT"
 ```
 


### PR DESCRIPTION
## Summary
0.1.1 is now on Maven Central, but the README only had a single `-SNAPSHOT` dependency line. `release.sbt`'s `updateReadme` step only rewrites a `libraryDependencies` line whose SNAPSHOT-ness matches the version being set, so that line never showed a release. Add a release line (`0.1.1`) and keep the snapshot line with the Central snapshots resolver, so future releases update both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jQpL8pgDmhRGdkNKAsP1s