### PR TITLE
ci: run every test with `testFull`, not the incremental `test`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,4 +27,4 @@ jobs:
           key: sbt-cache-${{ hashFiles('**/*.sbt') }}
           restore-keys: sbt-cache-
       - name: Test
-        run: sbt test
+        run: sbt testFull

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 # Compile
 sbt compile
 
-# Run all tests
-sbt test
+# Run all tests. In sbt 2 the plain `test` task is INCREMENTAL (it is an alias for
+# `testQuick`: only tests that failed before, never ran, or whose dependencies changed).
+# `testFull` is the one that always runs everything — use it in CI and before a release.
+sbt testFull
 
 # Run a single test suite
 sbt "testOnly com.github.kmizu.macro_peg.ParserSpec"

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Coming soon.
 Execute the following command:
 
 ```bash
-sbt test
+sbt testFull   # `sbt test` is incremental in sbt 2 (alias for testQuick)
 ```
 
 ## License


### PR DESCRIPTION
## The problem
sbt 2 changed what `test` means:

```
$ sbt "help test"
Executes the tests that either failed before, were not run or whose transitive dependencies changed, among those provided as arguments.

$ sbt "help testQuick"
Alias for test.

$ sbt "help testFull"
Executes all tests.
```

CI runs `sbt test`. A clean runner has no prior test state, so today everything still runs — but the green tick no longer *means* "all tests ran", and it stops meaning it as soon as any test state survives between runs (a cached `target/`, a reused workspace, a self-hosted runner).

The effect is already visible locally on `main`:

| command | suites run | tests run |
|---|---|---|
| `sbt test` (after a previous run) | 5 of 34 | 19 |
| `sbt "clean; test"` | 0 | `No tests to run for Test / testQuick` |
| `sbt testFull` | 34 | 607 |

This came in with the sbt 2 migration (#202) and was not noticed because CI stayed green.

## The change
- `.github/workflows/ci.yml`: `sbt test` → `sbt testFull`.
- `CLAUDE.md` and `README.md`: document the distinction so the incremental task is not used for verification.

## Test plan
- [x] `sbt testFull` locally: 34 suites, 607 tests, 0 failures
- [ ] CI green on this PR (and now actually running the whole suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jQpL8pgDmhRGdkNKAsP1s